### PR TITLE
refactor: make CLI methods private by reorganizing cmd structure

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"fmt"
@@ -22,14 +22,14 @@ import (
 	"github.com/alowayed/go-univers/pkg/univers"
 )
 
-// Run is the main entry point for the CLI
-func Run(args []string) int {
-	out, code := run(args)
+// run is the main entry point for the CLI
+func run(args []string) int {
+	out, code := runWithCode(args)
 	fmt.Printf("%s\n", out)
 	return code
 }
 
-func run(args []string) (string, int) {
+func runWithCode(args []string) (string, int) {
 	if len(args) == 0 {
 		s := "Usage: univers <ecosystem|spec> <command> [args]"
 		return s, 1

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/alowayed/go-univers/pkg/ecosystem/alpine"
@@ -23,16 +24,11 @@ import (
 )
 
 // run is the main entry point for the CLI
-func run(args []string) int {
-	out, code := runWithCode(args)
-	fmt.Printf("%s\n", out)
-	return code
-}
-
-func runWithCode(args []string) (string, int) {
+func run(w io.Writer, args []string) int {
 	if len(args) == 0 {
 		s := "Usage: univers <ecosystem|spec> <command> [args]"
-		return s, 1
+		fmt.Fprintf(w, "%s\n", s)
+		return 1
 	}
 
 	// Handle spec commands first
@@ -41,7 +37,9 @@ func runWithCode(args []string) (string, int) {
 	}
 
 	if fn, ok := specToRun[args[0]]; ok {
-		return fn(args[1:])
+		out, code := fn(args[1:])
+		fmt.Fprintf(w, "%s\n", out)
+		return code
 	}
 
 	ecosystemToRun := map[string]func([]string) (string, int){
@@ -93,11 +91,14 @@ func runWithCode(args []string) (string, int) {
 	}
 
 	if fn, ok := ecosystemToRun[args[0]]; ok {
-		return fn(args[1:])
+		out, code := fn(args[1:])
+		fmt.Fprintf(w, "%s\n", out)
+		return code
 	}
 
 	s := fmt.Sprintf("Unknown ecosystem: %s", args[0])
-	return s, 1
+	fmt.Fprintf(w, "%s\n", s)
+	return 1
 }
 
 func runEcosystem[V univers.Version[V], VR univers.VersionRange[V]](

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"testing"
@@ -84,7 +84,7 @@ func TestRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCode := Run(tt.args)
+			gotCode := run(tt.args)
 			if gotCode != tt.wantCode {
 				t.Errorf("Run(%+v) = %v, want %v", tt.args, gotCode, tt.wantCode)
 			}
@@ -421,7 +421,7 @@ func TestRun_Private(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOut, gotCode := run(tt.args)
+			gotOut, gotCode := runWithCode(tt.args)
 			if gotOut != tt.wantOut {
 				t.Errorf("run(%+v) out = %q, want %q", tt.args, gotOut, tt.wantOut)
 			}

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"testing"
 )
 
@@ -84,7 +86,7 @@ func TestRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotCode := run(tt.args)
+			gotCode := run(io.Discard, tt.args)
 			if gotCode != tt.wantCode {
 				t.Errorf("Run(%+v) = %v, want %v", tt.args, gotCode, tt.wantCode)
 			}
@@ -421,7 +423,13 @@ func TestRun_Private(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOut, gotCode := runWithCode(tt.args)
+			var buf bytes.Buffer
+			gotCode := run(&buf, tt.args)
+			gotOut := buf.String()
+			// Remove trailing newline for comparison
+			if len(gotOut) > 0 && gotOut[len(gotOut)-1] == '\n' {
+				gotOut = gotOut[:len(gotOut)-1]
+			}
 			if gotOut != tt.wantOut {
 				t.Errorf("run(%+v) out = %q, want %q", tt.args, gotOut, tt.wantOut)
 			}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"fmt"

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -1,4 +1,4 @@
-package cli
+package main
 
 import (
 	"testing"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	os.Exit(run(os.Args[1:]))
+	os.Exit(run(os.Stdout, os.Args[1:]))
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"os"
-
-	"github.com/alowayed/go-univers/cmd/cli"
 )
 
 func main() {
-	os.Exit(cli.Run(os.Args[1:]))
+	os.Exit(run(os.Args[1:]))
 }


### PR DESCRIPTION
## Summary

- Move CLI implementation from `cmd/cli/` package to main package in `cmd/`
- Change public `Run` function to private `run` function for better encapsulation  
- Consolidate cli.go, cli_test.go, commands.go, commands_test.go into cmd/ directory
- Update main.go and tests to use private `run`/`runWithCode` functions
- Maintain all existing functionality while hiding internal CLI methods

## Test plan

- [x] All existing tests pass
- [x] CLI functionality verified with manual testing
- [x] Code quality checks pass (golangci-lint)
- [x] Binary builds successfully
- [x] All CLI commands work correctly:
  - `npm compare "1.0.0" "2.0.0"` → `-1`
  - `npm sort "2.0.0" "1.0.0" "1.5.0"` → `"1.0.0" "1.5.0" "2.0.0"`
  - `npm contains "^1.0.0" "1.5.0"` → `true` 
  - `vers contains "vers:npm/>=1.0.0|<=2.0.0" "1.5.0"` → `true`

🤖 Generated with [Claude Code](https://claude.ai/code)