### PR TITLE
feat: add VERS cargo versioning scheme support

### DIFF
--- a/pkg/spec/vers/cargo.go
+++ b/pkg/spec/vers/cargo.go
@@ -1,0 +1,52 @@
+package vers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alowayed/go-univers/pkg/ecosystem/cargo"
+)
+
+// cargoContains implements VERS constraint checking for Cargo (Rust) ecosystem
+func cargoContains(constraints []string, version string) (bool, error) {
+	e := &cargo.Ecosystem{}
+	return contains(e, constraints, version)
+}
+
+// intervalToCargoRanges converts an interval to Cargo range syntax
+func intervalToCargoRanges(interval interval) []string {
+	// Handle exact matches
+	if interval.exact != "" {
+		return []string{fmt.Sprintf("=%s", interval.exact)}
+	}
+
+	// Exclusions are handled separately, not as cargo ranges
+	if interval.exclude != "" {
+		return []string{} // Return empty - excludes handled in contains function
+	}
+
+	// Handle regular intervals with bounds
+	var parts []string
+	if interval.lower != "" {
+		op := ">"
+		if interval.lowerInclusive {
+			op = ">="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.lower))
+	}
+	if interval.upper != "" {
+		op := "<"
+		if interval.upperInclusive {
+			op = "<="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.upper))
+	}
+
+	if len(parts) > 0 {
+		// Cargo uses comma-separated constraints like gem
+		return []string{strings.Join(parts, ",")}
+	}
+
+	// Empty interval
+	return []string{}
+}

--- a/pkg/spec/vers/cargo_test.go
+++ b/pkg/spec/vers/cargo_test.go
@@ -1,0 +1,227 @@
+package vers
+
+import (
+	"testing"
+)
+
+// TestContains_Cargo tests VERS functionality specifically for the Cargo (Rust) ecosystem
+func TestContains_Cargo(t *testing.T) {
+	tests := []struct {
+		name      string
+		versRange string
+		version   string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "cargo simple range - contained",
+			versRange: "vers:cargo/>=1.0.0|<=2.0.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo simple range - not contained",
+			versRange: "vers:cargo/>=2.0.0|<=3.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo exact match",
+			versRange: "vers:cargo/=1.5.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo exact match - not equal",
+			versRange: "vers:cargo/=1.5.0",
+			version:   "1.6.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo lower bound only",
+			versRange: "vers:cargo/>=1.0.0",
+			version:   "2.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo upper bound only",
+			versRange: "vers:cargo/<=2.0.0",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo greater than",
+			versRange: "vers:cargo/>1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo greater than - not satisfied",
+			versRange: "vers:cargo/>1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo less than",
+			versRange: "vers:cargo/<2.0.0",
+			version:   "1.9.9",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo less than - not satisfied",
+			versRange: "vers:cargo/<2.0.0",
+			version:   "2.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo not equal - satisfied",
+			versRange: "vers:cargo/!=1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo not equal - not satisfied",
+			versRange: "vers:cargo/!=1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo multiple constraints - AND logic",
+			versRange: "vers:cargo/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.2.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo multiple constraints - excluded",
+			versRange: "vers:cargo/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.5.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo prerelease version",
+			versRange: "vers:cargo/>=1.0.0-alpha.1",
+			version:   "1.0.0-alpha.2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo prerelease vs release",
+			versRange: "vers:cargo/>=1.0.0",
+			version:   "1.0.0-alpha.1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo release vs prerelease",
+			versRange: "vers:cargo/>=1.0.0-alpha.1",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo complex prerelease",
+			versRange: "vers:cargo/>=1.0.0-alpha.1|<2.0.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo complex prerelease - contained",
+			versRange: "vers:cargo/>=1.0.0-alpha.1|<2.0.0",
+			version:   "1.0.0-alpha.5",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo complex prerelease - not contained",
+			versRange: "vers:cargo/>=1.0.0-alpha.5|<2.0.0",
+			version:   "1.0.0-alpha.1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo with build metadata - equal",
+			versRange: "vers:cargo/>=1.0.0+build123",
+			version:   "1.0.0+build456",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo with build metadata - contained",
+			versRange: "vers:cargo/>=1.0.0+build123|<2.0.0",
+			version:   "1.5.0+other",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo prerelease with build metadata",
+			versRange: "vers:cargo/>=1.0.0-alpha.1+build|<2.0.0",
+			version:   "1.0.0-beta.1+another",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo star constraint - matches all",
+			versRange: "vers:cargo/*",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo star constraint - matches prerelease",
+			versRange: "vers:cargo/*",
+			version:   "1.0.0-alpha.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "cargo star constraint - matches build metadata",
+			versRange: "vers:cargo/*",
+			version:   "1.0.0+build123",
+			want:      true,
+			wantErr:   false,
+		},
+		// Error cases
+		{
+			name:      "cargo invalid version",
+			versRange: "vers:cargo/>=1.0.0",
+			version:   "invalid-version",
+			want:      false,
+			wantErr:   true,
+		},
+		{
+			name:      "cargo invalid constraint version",
+			versRange: "vers:cargo/>=invalid",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Contains(tt.versRange, tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Contains() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/spec/vers/vers.go
+++ b/pkg/spec/vers/vers.go
@@ -9,7 +9,7 @@
 //	vers:pypi/>=1.2.3|<=2.0.0
 //	vers:golang/>=v1.2.3|<=v2.0.0
 //
-// Supported ecosystems: alpine, gem, maven, npm, pypi, golang
+// Supported ecosystems: alpine, cargo, gem, maven, npm, pypi, golang
 // Supported operators: >=, <=, >, <, =, !=
 //
 // This package provides stateless functions for working with VERS notation.
@@ -312,6 +312,8 @@ func toRanges[V univers.Version[V], VR univers.VersionRange[V]](
 		switch e.Name() {
 		case "alpine":
 			rangeStrs = intervalToAlpineRanges(interval)
+		case "cargo":
+			rangeStrs = intervalToCargoRanges(interval)
 		case "gem":
 			rangeStrs = intervalToGemRanges(interval)
 		case "maven":
@@ -594,6 +596,7 @@ func Contains(versRange, version string) (bool, error) {
 
 	schemeToContains := map[string]func([]string, string) (bool, error){
 		"alpine": alpineContains,
+		"cargo":  cargoContains,
 		"gem":    gemContains,
 		"maven":  mavenContains,
 		"npm":    npmContains,


### PR DESCRIPTION
## Summary

Implements VERS (Version Range Specification) support for the Cargo (Rust) ecosystem, enabling users to use VERS range notation with Cargo versions like `vers:cargo/>=1.2.0|<2.0.0`.

- **Add `cargoContains()` function** for Cargo (Rust) VERS constraint checking
- **Add `intervalToCargoRanges()` function** to convert intervals to cargo range syntax  
- **Update vers.go** to include cargo in `schemeToContains` map and `toRanges` switch
- **Comprehensive test suite** covering all VERS operators and edge cases
- **CLI integration** with command `univers vers contains "vers:cargo/>=1.2.0" "1.5.0"`

## Implementation Details

Following the established pattern used for npm, pypi, go, maven, gem, and alpine VERS schemes:
- Created `pkg/spec/vers/cargo.go` with cargo-specific VERS functions
- Updated `pkg/spec/vers/vers.go` to register cargo support
- Added comprehensive tests in `pkg/spec/vers/cargo_test.go`

Key implementation insight: Cargo uses comma-separated constraints (like gem), so `intervalToCargoRanges` generates ranges like `>=1.0.0,<=2.0.0`, which aligns with Cargo's constraint syntax.

## Test Plan

- [x] All existing tests pass (no regressions)
- [x] New comprehensive test suite with 28 test cases
- [x] Code quality checks pass (golangci-lint)
- [x] CLI functionality verified

### Success Criteria Verification

- [x] **Support VERS Cargo ranges**: `vers:cargo/>=1.2.0` → ✅
- [x] **Handle prerelease versions**: `vers:cargo/>=1.0.0-alpha.1|<2.0.0` → ✅  
- [x] **Handle metadata versions**: `vers:cargo/>=1.0.0+build123` → ✅
- [x] **Support all VERS operators**: `>=`, `<=`, `>`, `<`, `=`, `!=` → ✅
- [x] **Pass comprehensive test suite** covering edge cases → ✅
- [x] **CLI integration**: `univers vers contains "vers:cargo/>=1.2.0" "1.5.0"` → ✅
- [x] **Consistent behavior** with existing Cargo ecosystem implementation → ✅

## Examples

```bash
# Basic range
univers vers contains "vers:cargo/>=1.2.0|<=2.0.0" "1.5.0"  # → true

# Prerelease support  
univers vers contains "vers:cargo/>=1.0.0-alpha.1|<2.0.0" "1.5.0"  # → true

# Build metadata support
univers vers contains "vers:cargo/>=1.0.0+build123" "1.5.0+other"  # → true

# Exclusion operator
univers vers contains "vers:cargo/>=1.0.0|!=1.5.0" "1.5.0"  # → false

# All operators supported
univers vers contains "vers:cargo/>1.0.0|<2.0.0" "1.5.0"  # → true
```

## Cargo-Specific Features

This implementation fully supports Cargo's SemVer 2.0 extensions:
- **Prerelease versions**: `1.0.0-alpha.1`, `1.0.0-beta.2`
- **Build metadata**: `1.0.0+build123` (ignored in comparisons per SemVer spec)
- **Full SemVer compliance**: Compatible with existing Cargo ecosystem implementation

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)