### PR TITLE
feat: add VERS semver versioning scheme support

### DIFF
--- a/pkg/spec/vers/semver.go
+++ b/pkg/spec/vers/semver.go
@@ -1,0 +1,52 @@
+package vers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alowayed/go-univers/pkg/ecosystem/semver"
+)
+
+// semverContains implements VERS constraint checking for generic SemVer ecosystem
+func semverContains(constraints []string, version string) (bool, error) {
+	e := &semver.Ecosystem{}
+	return contains(e, constraints, version)
+}
+
+// intervalToSemverRanges converts an interval to SemVer range syntax
+func intervalToSemverRanges(interval interval) []string {
+	// Handle exact matches
+	if interval.exact != "" {
+		return []string{fmt.Sprintf("=%s", interval.exact)}
+	}
+
+	// Exclusions are handled separately, not as semver ranges
+	if interval.exclude != "" {
+		return []string{} // Return empty - excludes handled in contains function
+	}
+
+	// Handle regular intervals with bounds
+	var parts []string
+	if interval.lower != "" {
+		op := ">"
+		if interval.lowerInclusive {
+			op = ">="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.lower))
+	}
+	if interval.upper != "" {
+		op := "<"
+		if interval.upperInclusive {
+			op = "<="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.upper))
+	}
+
+	if len(parts) > 0 {
+		// SemVer supports both space and comma-separated, using space-separated like npm
+		return []string{strings.Join(parts, " ")}
+	}
+
+	// Empty interval
+	return []string{}
+}

--- a/pkg/spec/vers/semver_test.go
+++ b/pkg/spec/vers/semver_test.go
@@ -1,0 +1,234 @@
+package vers
+
+import (
+	"testing"
+)
+
+// TestContains_SemVer tests VERS functionality specifically for the generic SemVer ecosystem
+func TestContains_SemVer(t *testing.T) {
+	tests := []struct {
+		name      string
+		versRange string
+		version   string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "semver simple range - contained",
+			versRange: "vers:semver/>=1.0.0|<=2.0.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver simple range - not contained",
+			versRange: "vers:semver/>=2.0.0|<=3.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver exact match",
+			versRange: "vers:semver/=1.5.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver exact match - not equal",
+			versRange: "vers:semver/=1.5.0",
+			version:   "1.6.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver lower bound only",
+			versRange: "vers:semver/>=1.0.0",
+			version:   "2.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver upper bound only",
+			versRange: "vers:semver/<=2.0.0",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver greater than",
+			versRange: "vers:semver/>1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver greater than - not satisfied",
+			versRange: "vers:semver/>1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver less than",
+			versRange: "vers:semver/<2.0.0",
+			version:   "1.9.9",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver less than - not satisfied",
+			versRange: "vers:semver/<2.0.0",
+			version:   "2.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver not equal - satisfied",
+			versRange: "vers:semver/!=1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver not equal - not satisfied",
+			versRange: "vers:semver/!=1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver multiple constraints - AND logic",
+			versRange: "vers:semver/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.2.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver multiple constraints - excluded",
+			versRange: "vers:semver/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.5.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver prerelease version",
+			versRange: "vers:semver/>=1.0.0-alpha.1",
+			version:   "1.0.0-alpha.2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver prerelease vs release",
+			versRange: "vers:semver/>=1.0.0",
+			version:   "1.0.0-alpha.1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver release vs prerelease",
+			versRange: "vers:semver/>=1.0.0-alpha.1",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver complex prerelease",
+			versRange: "vers:semver/>=1.0.0-alpha.1|<2.0.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver complex prerelease - contained",
+			versRange: "vers:semver/>=1.0.0-alpha.1|<2.0.0",
+			version:   "1.0.0-alpha.5",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver complex prerelease - not contained",
+			versRange: "vers:semver/>=1.0.0-alpha.5|<2.0.0",
+			version:   "1.0.0-alpha.1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "semver with build metadata - equal",
+			versRange: "vers:semver/>=1.0.0+build123",
+			version:   "1.0.0+build456",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver with build metadata - contained",
+			versRange: "vers:semver/>=1.0.0+build123|<2.0.0",
+			version:   "1.5.0+other",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver prerelease with build metadata",
+			versRange: "vers:semver/>=1.0.0-alpha.1+build|<2.0.0",
+			version:   "1.0.0-beta.1+another",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver comprehensive range",
+			versRange: "vers:semver/>=1.0.0-alpha|<=2.0.0-beta+build",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver star constraint - matches all",
+			versRange: "vers:semver/*",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver star constraint - matches prerelease",
+			versRange: "vers:semver/*",
+			version:   "1.0.0-alpha.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "semver star constraint - matches build metadata",
+			versRange: "vers:semver/*",
+			version:   "1.0.0+build123",
+			want:      true,
+			wantErr:   false,
+		},
+		// Error cases
+		{
+			name:      "semver invalid version",
+			versRange: "vers:semver/>=1.0.0",
+			version:   "invalid-version",
+			want:      false,
+			wantErr:   true,
+		},
+		{
+			name:      "semver invalid constraint version",
+			versRange: "vers:semver/>=invalid",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Contains(tt.versRange, tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Contains() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/spec/vers/vers.go
+++ b/pkg/spec/vers/vers.go
@@ -9,7 +9,7 @@
 //	vers:pypi/>=1.2.3|<=2.0.0
 //	vers:golang/>=v1.2.3|<=v2.0.0
 //
-// Supported ecosystems: alpine, cargo, gem, maven, npm, pypi, golang
+// Supported ecosystems: alpine, cargo, gem, maven, npm, pypi, semver, golang
 // Supported operators: >=, <=, >, <, =, !=
 //
 // This package provides stateless functions for working with VERS notation.
@@ -322,6 +322,8 @@ func toRanges[V univers.Version[V], VR univers.VersionRange[V]](
 			rangeStrs = intervalToNpmRanges(interval)
 		case "pypi":
 			rangeStrs = intervalToPypiRanges(interval)
+		case "semver":
+			rangeStrs = intervalToSemverRanges(interval)
 		case "go":
 			rangeStrs = intervalToGomodRanges(interval)
 		default:
@@ -601,6 +603,7 @@ func Contains(versRange, version string) (bool, error) {
 		"maven":  mavenContains,
 		"npm":    npmContains,
 		"pypi":   pypiContains,
+		"semver": semverContains,
 		"golang": gomodContains,
 	}
 


### PR DESCRIPTION
## Summary

Implements VERS (Version Range Specification) support for the generic SemVer ecosystem, enabling users to use VERS range notation with SemVer versions like `vers:semver/>=1.2.0|<2.0.0`.

- **Add `semverContains()` function** for generic SemVer VERS constraint checking
- **Add `intervalToSemverRanges()` function** to convert intervals to semver range syntax  
- **Update vers.go** to include semver in `schemeToContains` map and `toRanges` switch
- **Comprehensive test suite** covering all VERS operators and edge cases
- **CLI integration** with command `univers vers contains "vers:semver/>=1.2.0" "1.5.0"`

## Implementation Details

Following the established pattern used for npm, pypi, go, maven, gem, cargo, and alpine VERS schemes:
- Created `pkg/spec/vers/semver.go` with semver-specific VERS functions
- Updated `pkg/spec/vers/vers.go` to register semver support
- Added comprehensive tests in `pkg/spec/vers/semver_test.go`

Key implementation insight: SemVer supports both space-separated and comma-separated constraints. We chose space-separated (like npm) for consistency and simplicity, generating ranges like `>=1.0.0 <=2.0.0`.

## Test Plan

- [x] All existing tests pass (no regressions)
- [x] New comprehensive test suite with 29 test cases
- [x] Code quality checks pass (golangci-lint)
- [x] CLI functionality verified

### Success Criteria Verification

- [x] **Support VERS SemVer ranges**: `vers:semver/>=1.2.0` → ✅
- [x] **Handle prerelease versions**: `vers:semver/>=1.0.0-alpha.1|<2.0.0` → ✅  
- [x] **Handle metadata versions**: `vers:semver/>=1.0.0+build123` → ✅
- [x] **Support all VERS operators**: `>=`, `<=`, `>`, `<`, `=`, `!=` → ✅
- [x] **Pass comprehensive test suite** covering edge cases → ✅
- [x] **CLI integration**: `univers vers contains "vers:semver/>=1.2.0" "1.5.0"` → ✅
- [x] **Consistent behavior** with existing SemVer ecosystem implementation → ✅

## Examples

```bash
# Basic range
univers vers contains "vers:semver/>=1.2.0|<=2.0.0" "1.5.0"  # → true

# Prerelease support  
univers vers contains "vers:semver/>=1.0.0-alpha.1|<2.0.0" "1.5.0"  # → true

# Build metadata support
univers vers contains "vers:semver/>=1.0.0+build123" "1.5.0+other"  # → true

# Exclusion operator
univers vers contains "vers:semver/>=1.0.0|!=1.5.0" "1.5.0"  # → false

# All operators supported
univers vers contains "vers:semver/>1.0.0|<2.0.0" "1.5.0"  # → true

# Complex constraints
univers vers contains "vers:semver/>=1.0.0-alpha|<=2.0.0-beta+build" "1.5.0"  # → true
```

## SemVer 2.0.0 Features

This implementation provides full Semantic Versioning 2.0.0 support:
- **Standard versioning**: `MAJOR.MINOR.PATCH` format
- **Prerelease versions**: `1.0.0-alpha.1`, `1.0.0-beta.2`
- **Build metadata**: `1.0.0+build123` (ignored in comparisons per SemVer spec)
- **Pure SemVer**: No ecosystem-specific extensions, following the official specification exactly

Fixes #56

🤖 Generated with [Claude Code](https://claude.ai/code)