### PR TITLE
feat: add VERS debian versioning scheme support

### DIFF
--- a/pkg/spec/vers/debian.go
+++ b/pkg/spec/vers/debian.go
@@ -1,0 +1,52 @@
+package vers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alowayed/go-univers/pkg/ecosystem/debian"
+)
+
+// debianContains implements VERS constraint checking for Debian ecosystem
+func debianContains(constraints []string, version string) (bool, error) {
+	e := &debian.Ecosystem{}
+	return contains(e, constraints, version)
+}
+
+// intervalToDebianRanges converts an interval to Debian range syntax
+func intervalToDebianRanges(interval interval) []string {
+	// Handle exact matches
+	if interval.exact != "" {
+		return []string{fmt.Sprintf("=%s", interval.exact)}
+	}
+
+	// Exclusions are handled separately, not as Debian ranges
+	if interval.exclude != "" {
+		return []string{} // Return empty - excludes handled in contains function
+	}
+
+	// Handle regular intervals with bounds
+	var parts []string
+	if interval.lower != "" {
+		op := ">"
+		if interval.lowerInclusive {
+			op = ">="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.lower))
+	}
+	if interval.upper != "" {
+		op := "<"
+		if interval.upperInclusive {
+			op = "<="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.upper))
+	}
+
+	if len(parts) > 0 {
+		// Debian supports comma-separated constraints like rpm, gem and cargo
+		return []string{strings.Join(parts, ",")}
+	}
+
+	// Empty interval
+	return []string{}
+}

--- a/pkg/spec/vers/debian_test.go
+++ b/pkg/spec/vers/debian_test.go
@@ -1,0 +1,255 @@
+package vers
+
+import (
+	"testing"
+)
+
+// TestContains_Debian tests VERS functionality specifically for the Debian ecosystem
+func TestContains_Debian(t *testing.T) {
+	tests := []struct {
+		name      string
+		versRange string
+		version   string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "debian simple range - contained",
+			versRange: "vers:debian/>=1.0.0|<=2.0.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian simple range - not contained",
+			versRange: "vers:debian/>=2.0.0|<=3.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian exact match",
+			versRange: "vers:debian/=1.5.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian exact match - not equal",
+			versRange: "vers:debian/=1.5.0",
+			version:   "1.6.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian lower bound only",
+			versRange: "vers:debian/>=1.0.0",
+			version:   "2.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian upper bound only",
+			versRange: "vers:debian/<=2.0.0",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian greater than",
+			versRange: "vers:debian/>1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian greater than - not satisfied",
+			versRange: "vers:debian/>1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian less than",
+			versRange: "vers:debian/<2.0.0",
+			version:   "1.9.9",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian less than - not satisfied",
+			versRange: "vers:debian/<2.0.0",
+			version:   "2.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian not equal - satisfied",
+			versRange: "vers:debian/!=1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian not equal - not satisfied",
+			versRange: "vers:debian/!=1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian multiple constraints - AND logic",
+			versRange: "vers:debian/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.2.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian multiple constraints - excluded",
+			versRange: "vers:debian/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.5.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian epoch version - contained",
+			versRange: "vers:debian/>=1:1.0.0",
+			version:   "1:2.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian epoch version - not contained",
+			versRange: "vers:debian/>=2:1.0.0",
+			version:   "1:2.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian epoch version range",
+			versRange: "vers:debian/>=1:2.4.1|<1:3.0.0",
+			version:   "1:2.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian epoch version range - not contained",
+			versRange: "vers:debian/>=2:1.0.0|<=2:2.0.0",
+			version:   "1:5.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian revision version - contained",
+			versRange: "vers:debian/>=2.4.1-1",
+			version:   "2.4.1-2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian revision version - not contained",
+			versRange: "vers:debian/>=2.4.2-1",
+			version:   "2.4.1-9",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian ubuntu revision version",
+			versRange: "vers:debian/>=2.4.1-1ubuntu1|<2.4.2",
+			version:   "2.4.1-1ubuntu2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian ubuntu revision version - not contained",
+			versRange: "vers:debian/>=2.4.1-1ubuntu1|<2.4.2",
+			version:   "2.4.2-1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian epoch and revision version",
+			versRange: "vers:debian/>=1:2.4.1-1|<1:3.0.0-1",
+			version:   "1:2.5.0-2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian epoch and revision version - not contained",
+			versRange: "vers:debian/>=1:2.4.1-1|<1:3.0.0-1",
+			version:   "1:4.0.0-1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian complex epoch range",
+			versRange: "vers:debian/>=1:2.4.1-1|<=1:3.0.0-1|!=1:2.5.0-1",
+			version:   "1:2.6.0-1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian complex epoch range - excluded",
+			versRange: "vers:debian/>=1:2.4.1-1|<=1:3.0.0-1|!=1:2.5.0-1",
+			version:   "1:2.5.0-1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "debian star constraint - matches all",
+			versRange: "vers:debian/*",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian star constraint - matches epoch",
+			versRange: "vers:debian/*",
+			version:   "1:2.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian star constraint - matches revision",
+			versRange: "vers:debian/*",
+			version:   "2.0.0-1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "debian star constraint - matches epoch and revision",
+			versRange: "vers:debian/*",
+			version:   "1:2.0.0-1ubuntu1",
+			want:      true,
+			wantErr:   false,
+		},
+		// Error cases
+		{
+			name:      "debian invalid version",
+			versRange: "vers:debian/>=1.0.0",
+			version:   "1.0.0@invalid",
+			want:      false,
+			wantErr:   true,
+		},
+		{
+			name:      "debian invalid constraint version",
+			versRange: "vers:debian/>=1.0.0@invalid",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Contains(tt.versRange, tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Contains() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/spec/vers/vers.go
+++ b/pkg/spec/vers/vers.go
@@ -9,7 +9,7 @@
 //	vers:pypi/>=1.2.3|<=2.0.0
 //	vers:golang/>=v1.2.3|<=v2.0.0
 //
-// Supported ecosystems: alpine, cargo, gem, maven, npm, pypi, rpm, semver, golang
+// Supported ecosystems: alpine, cargo, debian, gem, maven, npm, pypi, rpm, semver, golang
 // Supported operators: >=, <=, >, <, =, !=
 //
 // This package provides stateless functions for working with VERS notation.
@@ -314,6 +314,8 @@ func toRanges[V univers.Version[V], VR univers.VersionRange[V]](
 			rangeStrs = intervalToAlpineRanges(interval)
 		case "cargo":
 			rangeStrs = intervalToCargoRanges(interval)
+		case "debian":
+			rangeStrs = intervalToDebianRanges(interval)
 		case "gem":
 			rangeStrs = intervalToGemRanges(interval)
 		case "maven":
@@ -601,6 +603,7 @@ func Contains(versRange, version string) (bool, error) {
 	schemeToContains := map[string]func([]string, string) (bool, error){
 		"alpine": alpineContains,
 		"cargo":  cargoContains,
+		"debian": debianContains,
 		"gem":    gemContains,
 		"maven":  mavenContains,
 		"npm":    npmContains,


### PR DESCRIPTION
## Summary

This PR implements VERS (Version Range Specification) support for the Debian ecosystem, addressing issue #55.

- ✅ Adds `debianContains()` and `intervalToDebianRanges()` functions in `pkg/spec/vers/debian.go`
- ✅ Comprehensive test suite with 32 test cases covering all scenarios
- ✅ Supports epoch versions: `vers:debian/>=1:2.4.1-1|<1:3.0.0`
- ✅ Supports revision versions: `vers:debian/>=2.4.1-1ubuntu1|<2.4.2`
- ✅ All VERS operators: `>=`, `<=`, `>`, `<`, `=`, `!=`
- ✅ CLI integration: `univers vers contains "vers:debian/>=1:2.4.1" "1:2.5.0-1"`
- ✅ Uses comma-separated constraints like rpm, gem and cargo for consistency

## Examples

### Epoch versions
```bash
univers vers contains "vers:debian/>=1:2.4.1-1" "1:2.5.0-1"       # → true
univers vers contains "vers:debian/>=2:1.0.0|<=2:2.0.0" "1:5.0.0" # → false
```

### Debian revision versions (including Ubuntu)
```bash
univers vers contains "vers:debian/>=2.4.1-1ubuntu1" "2.4.1-2ubuntu1" # → true
```

### Complex ranges with epochs and revisions
```bash
univers vers contains "vers:debian/>=1:2.4.1-1|<1:3.0.0|!=1:2.5.0" "1:2.6.0-1" # → true
```

## Test Plan

- [x] All 32 test cases pass including epoch, revision, and error scenarios
- [x] CLI integration verified with epoch and Ubuntu revision versions
- [x] Full test suite passes (no regressions)
- [x] Code formatting and linting passes
- [x] Follows established VERS implementation patterns

## References

- Fixes #55
- Follows patterns established in npm (#35), pypi (#36), go (#37) VERS implementations
- [VERS Specification](https://github.com/package-url/purl-spec/blob/main/VERSION-RANGE-SPEC.rst)
- [Debian Policy Manual - Version numbering](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version)

🤖 Generated with [Claude Code](https://claude.ai/code)