### PR TITLE
feat: add VERS nuget versioning scheme support

### DIFF
--- a/pkg/spec/vers/nuget.go
+++ b/pkg/spec/vers/nuget.go
@@ -2,7 +2,6 @@ package vers
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/alowayed/go-univers/pkg/ecosystem/nuget"
 )
@@ -15,54 +14,38 @@ func nugetContains(constraints []string, version string) (bool, error) {
 
 // intervalToNugetRanges converts an interval to NuGet range syntax
 func intervalToNugetRanges(interval interval) []string {
-	// Handle exact matches - NuGet uses bracket notation for exact matches
-	if interval.exact != "" {
+	switch {
+	case interval.exact != "":
+		// Handle exact matches - NuGet uses bracket notation for exact matches
 		return []string{fmt.Sprintf("[%s]", interval.exact)}
-	}
-
-	// Exclusions are handled separately, not as NuGet ranges
-	if interval.exclude != "" {
+	case interval.exclude != "":
+		// Exclusions are handled separately, not as NuGet ranges
 		return []string{} // Return empty - excludes handled in contains function
-	}
-
-	// Handle regular intervals with bounds
-	// NuGet has special handling for single bounds using unbounded ranges
-	if interval.lower != "" && interval.upper == "" {
+	case interval.lower != "" && interval.upper == "":
 		// Lower bound only - use unbounded range [version,) for inclusive, comma-separated constraint for exclusive
 		if interval.lowerInclusive {
 			return []string{fmt.Sprintf("[%s,)", interval.lower)}
-		} else {
-			// NuGet doesn't support (version,) syntax, use comma-separated constraint
-			return []string{fmt.Sprintf(">%s,", interval.lower)}
 		}
-	}
-
-	if interval.upper != "" && interval.lower == "" {
+		// NuGet doesn't support (version,) syntax, use comma-separated constraint
+		return []string{fmt.Sprintf(">%s,", interval.lower)}
+	case interval.upper != "" && interval.lower == "":
 		// Upper bound only - use unbounded range (,version] for inclusive, comma-separated constraint for exclusive
 		if interval.upperInclusive {
 			return []string{fmt.Sprintf("(,%s]", interval.upper)}
-		} else {
-			// NuGet doesn't support (,version) syntax, use comma-separated constraint
-			return []string{fmt.Sprintf("<%s,", interval.upper)}
 		}
-	}
-
-	if interval.lower != "" && interval.upper != "" {
+		// NuGet doesn't support (,version) syntax, use comma-separated constraint
+		return []string{fmt.Sprintf("<%s,", interval.upper)}
+	case interval.lower != "" && interval.upper != "":
 		// Both bounds - use comma-separated constraints
-		var parts []string
-		op := ">"
+		lowerOp := ">"
 		if interval.lowerInclusive {
-			op = ">="
+			lowerOp = ">="
 		}
-		parts = append(parts, fmt.Sprintf("%s%s", op, interval.lower))
-
-		op = "<"
+		upperOp := "<"
 		if interval.upperInclusive {
-			op = "<="
+			upperOp = "<="
 		}
-		parts = append(parts, fmt.Sprintf("%s%s", op, interval.upper))
-
-		return []string{strings.Join(parts, ",")}
+		return []string{fmt.Sprintf("%s%s,%s%s", lowerOp, interval.lower, upperOp, interval.upper)}
 	}
 
 	// Empty interval

--- a/pkg/spec/vers/nuget.go
+++ b/pkg/spec/vers/nuget.go
@@ -1,0 +1,70 @@
+package vers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alowayed/go-univers/pkg/ecosystem/nuget"
+)
+
+// nugetContains implements VERS constraint checking for NuGet ecosystem
+func nugetContains(constraints []string, version string) (bool, error) {
+	e := &nuget.Ecosystem{}
+	return contains(e, constraints, version)
+}
+
+// intervalToNugetRanges converts an interval to NuGet range syntax
+func intervalToNugetRanges(interval interval) []string {
+	// Handle exact matches - NuGet uses bracket notation for exact matches
+	if interval.exact != "" {
+		return []string{fmt.Sprintf("[%s]", interval.exact)}
+	}
+
+	// Exclusions are handled separately, not as NuGet ranges
+	if interval.exclude != "" {
+		return []string{} // Return empty - excludes handled in contains function
+	}
+
+	// Handle regular intervals with bounds
+	// NuGet has special handling for single bounds using unbounded ranges
+	if interval.lower != "" && interval.upper == "" {
+		// Lower bound only - use unbounded range [version,) for inclusive, comma-separated constraint for exclusive
+		if interval.lowerInclusive {
+			return []string{fmt.Sprintf("[%s,)", interval.lower)}
+		} else {
+			// NuGet doesn't support (version,) syntax, use comma-separated constraint
+			return []string{fmt.Sprintf(">%s,", interval.lower)}
+		}
+	}
+
+	if interval.upper != "" && interval.lower == "" {
+		// Upper bound only - use unbounded range (,version] for inclusive, comma-separated constraint for exclusive
+		if interval.upperInclusive {
+			return []string{fmt.Sprintf("(,%s]", interval.upper)}
+		} else {
+			// NuGet doesn't support (,version) syntax, use comma-separated constraint
+			return []string{fmt.Sprintf("<%s,", interval.upper)}
+		}
+	}
+
+	if interval.lower != "" && interval.upper != "" {
+		// Both bounds - use comma-separated constraints
+		var parts []string
+		op := ">"
+		if interval.lowerInclusive {
+			op = ">="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.lower))
+
+		op = "<"
+		if interval.upperInclusive {
+			op = "<="
+		}
+		parts = append(parts, fmt.Sprintf("%s%s", op, interval.upper))
+
+		return []string{strings.Join(parts, ",")}
+	}
+
+	// Empty interval
+	return []string{}
+}

--- a/pkg/spec/vers/nuget_test.go
+++ b/pkg/spec/vers/nuget_test.go
@@ -1,0 +1,255 @@
+package vers
+
+import (
+	"testing"
+)
+
+// TestContains_NuGet tests VERS functionality specifically for the NuGet ecosystem
+func TestContains_NuGet(t *testing.T) {
+	tests := []struct {
+		name      string
+		versRange string
+		version   string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "nuget simple range - contained",
+			versRange: "vers:nuget/>=1.0.0|<=2.0.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget simple range - not contained",
+			versRange: "vers:nuget/>=2.0.0|<=3.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget exact match",
+			versRange: "vers:nuget/=1.5.0",
+			version:   "1.5.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget exact match - not equal",
+			versRange: "vers:nuget/=1.5.0",
+			version:   "1.6.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget lower bound only",
+			versRange: "vers:nuget/>=1.0.0",
+			version:   "2.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget upper bound only",
+			versRange: "vers:nuget/<=2.0.0",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget greater than",
+			versRange: "vers:nuget/>1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget greater than - not satisfied",
+			versRange: "vers:nuget/>1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget less than",
+			versRange: "vers:nuget/<2.0.0",
+			version:   "1.9.9",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget less than - not satisfied",
+			versRange: "vers:nuget/<2.0.0",
+			version:   "2.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget not equal - satisfied",
+			versRange: "vers:nuget/!=1.0.0",
+			version:   "1.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget not equal - not satisfied",
+			versRange: "vers:nuget/!=1.0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget multiple constraints - AND logic",
+			versRange: "vers:nuget/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.2.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget multiple constraints - excluded",
+			versRange: "vers:nuget/>=1.0.0|<=2.0.0|!=1.5.0",
+			version:   "1.5.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget prerelease version - contained",
+			versRange: "vers:nuget/>=1.0.0-alpha",
+			version:   "1.0.0-alpha.2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget prerelease version - not contained",
+			versRange: "vers:nuget/>=1.0.0-beta",
+			version:   "1.0.0-alpha.2",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget prerelease vs release",
+			versRange: "vers:nuget/>=1.0.0",
+			version:   "1.0.0-alpha",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget release vs prerelease",
+			versRange: "vers:nuget/>=1.0.0-alpha",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget revision version - contained",
+			versRange: "vers:nuget/>=1.0.0.1",
+			version:   "1.0.0.2",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget revision version - not contained",
+			versRange: "vers:nuget/>=1.0.0.2",
+			version:   "1.0.0.1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget revision version range",
+			versRange: "vers:nuget/>=1.0.0.1|<2.0.0.0",
+			version:   "1.5.0.5",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget revision version range - not contained",
+			versRange: "vers:nuget/>=1.0.0.1|<2.0.0.0",
+			version:   "2.0.0.1",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget prerelease with revision",
+			versRange: "vers:nuget/>=1.0.0.1-alpha|<2.0.0.0",
+			version:   "1.5.0.2-beta",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget prerelease with revision - not contained",
+			versRange: "vers:nuget/>=1.0.0.1-beta|<2.0.0.0",
+			version:   "1.0.0.1-alpha",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget complex version range",
+			versRange: "vers:nuget/>=1.0.0.1|<=2.0.0.0|!=1.5.0.0",
+			version:   "1.2.0.5",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget complex version range - excluded",
+			versRange: "vers:nuget/>=1.0.0.1|<=2.0.0.0|!=1.5.0.0",
+			version:   "1.5.0.0",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget star constraint - matches all",
+			versRange: "vers:nuget/*",
+			version:   "1.0.0",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget star constraint - matches prerelease",
+			versRange: "vers:nuget/*",
+			version:   "1.0.0-alpha",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget star constraint - matches revision",
+			versRange: "vers:nuget/*",
+			version:   "1.0.0.1",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name:      "nuget star constraint - matches complex",
+			versRange: "vers:nuget/*",
+			version:   "1.0.0.1-alpha.2",
+			want:      true,
+			wantErr:   false,
+		},
+		// Error cases
+		{
+			name:      "nuget invalid version",
+			versRange: "vers:nuget/>=1.0.0",
+			version:   "1.0.0@invalid",
+			want:      false,
+			wantErr:   true,
+		},
+		{
+			name:      "nuget invalid constraint version",
+			versRange: "vers:nuget/>=1..0.0",
+			version:   "1.0.0",
+			want:      false,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Contains(tt.versRange, tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Contains() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/spec/vers/nuget_test.go
+++ b/pkg/spec/vers/nuget_test.go
@@ -242,6 +242,7 @@ func TestContains_NuGet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := Contains(tt.versRange, tt.version)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Contains() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/spec/vers/vers.go
+++ b/pkg/spec/vers/vers.go
@@ -9,7 +9,7 @@
 //	vers:pypi/>=1.2.3|<=2.0.0
 //	vers:golang/>=v1.2.3|<=v2.0.0
 //
-// Supported ecosystems: alpine, cargo, debian, gem, maven, npm, pypi, rpm, semver, golang
+// Supported ecosystems: alpine, cargo, debian, gem, maven, npm, nuget, pypi, rpm, semver, golang
 // Supported operators: >=, <=, >, <, =, !=
 //
 // This package provides stateless functions for working with VERS notation.
@@ -322,6 +322,8 @@ func toRanges[V univers.Version[V], VR univers.VersionRange[V]](
 			rangeStrs = intervalToMavenRanges(interval)
 		case "npm":
 			rangeStrs = intervalToNpmRanges(interval)
+		case "nuget":
+			rangeStrs = intervalToNugetRanges(interval)
 		case "pypi":
 			rangeStrs = intervalToPypiRanges(interval)
 		case "rpm":
@@ -607,6 +609,7 @@ func Contains(versRange, version string) (bool, error) {
 		"gem":    gemContains,
 		"maven":  mavenContains,
 		"npm":    npmContains,
+		"nuget":  nugetContains,
 		"pypi":   pypiContains,
 		"rpm":    rpmContains,
 		"semver": semverContains,


### PR DESCRIPTION
## Summary

This PR implements VERS (Version Range Specification) support for the NuGet ecosystem, addressing issue #58.

- ✅ Adds `nugetContains()` and `intervalToNugetRanges()` functions in `pkg/spec/vers/nuget.go`
- ✅ Comprehensive test suite with 32 test cases covering all scenarios
- ✅ Supports prerelease versions: `vers:nuget/>=1.0.0-alpha|<2.0.0`
- ✅ Supports revision versions: `vers:nuget/>=1.0.0.1|<2.0.0.0`
- ✅ All VERS operators: `>=`, `<=`, `>`, `<`, `=`, `!=`
- ✅ CLI integration: `univers vers contains "vers:nuget/>=1.2.0" "1.5.0"`
- ✅ Uses NuGet-specific range syntax for optimal compatibility

## Key Implementation Features

### NuGet-Specific Range Syntax
- **Exact matches**: Uses bracket notation `[1.5.0]` instead of `=1.5.0`
- **Inclusive single bounds**: Uses unbounded ranges `[1.0.0,)` and `(,2.0.0]`
- **Exclusive single bounds**: Uses comma-separated constraints `>1.0.0,` and `<2.0.0,`
- **Both bounds**: Uses standard comma-separated constraints `>=1.0.0,<2.0.0`

## Examples

### Prerelease versions
```bash
univers vers contains "vers:nuget/>=1.0.0-alpha" "1.0.0-beta"  # → true
univers vers contains "vers:nuget/>=1.0.0" "1.0.0-alpha"      # → false
```

### NuGet revision versions
```bash
univers vers contains "vers:nuget/>=1.0.0.1" "1.0.0.2"        # → true
univers vers contains "vers:nuget/>=1.0.0.1|<2.0.0.0" "1.5.0.5" # → true
```

### Complex ranges
```bash
univers vers contains "vers:nuget/>=1.0.0.1|<=2.0.0.0|!=1.5.0.0" "1.2.0.5" # → true
```

## Test Plan

- [x] All 32 test cases pass including prerelease, revision, and error scenarios
- [x] CLI integration verified with prerelease and revision versions
- [x] Full test suite passes (no regressions)
- [x] Code formatting and linting passes
- [x] Follows established VERS implementation patterns
- [x] NuGet-specific range syntax properly handled

## References

- Fixes #58
- Follows patterns established in npm (#35), pypi (#36), go (#37) VERS implementations
- [VERS Specification](https://github.com/package-url/purl-spec/blob/main/VERSION-RANGE-SPEC.rst)
- [NuGet Package Versioning](https://docs.microsoft.com/en-us/nuget/concepts/package-versioning)

🤖 Generated with [Claude Code](https://claude.ai/code)