### PR TITLE
feat: add Mattermost ecosystem support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ func main() {
 | **Go** | `pkg/ecosystem/gomod` | `golang` ✅ |
 | **Hex (Elixir)** | [❌](https://github.com/alowayed/go-univers/issues/79) | [`hex` ❌](https://github.com/alowayed/go-univers/issues/80) |
 | **Intdot** | [❌](https://github.com/alowayed/go-univers/issues/89) | [`intdot` ❌](https://github.com/alowayed/go-univers/issues/90) |
-| **Mattermost** | [❌](https://github.com/alowayed/go-univers/issues/87) | [`mattermost` ❌](https://github.com/alowayed/go-univers/issues/88) |
+| **Mattermost** | `pkg/ecosystem/mattermost` | [`mattermost` ❌](https://github.com/alowayed/go-univers/issues/88) |
 | **Maven** | `pkg/ecosystem/maven` | `maven` ✅ |
 | **Mozilla** | [❌](https://github.com/alowayed/go-univers/issues/85) | [`mozilla` ❌](https://github.com/alowayed/go-univers/issues/86) |
 | **Nginx** | [❌](https://github.com/alowayed/go-univers/issues/81) | [`nginx` ❌](https://github.com/alowayed/go-univers/issues/82) |
@@ -107,6 +107,7 @@ The CLI follows the pattern: `univers <ecosystem|spec> <command> [args]`
 univers npm compare "1.2.3" "1.2.4"           # → -1 (first < second)
 univers apache compare "2.4.40" "2.4.41"      # → -1 (first < second)
 univers github compare "v1.0.0" "v1.0.1"      # → -1 (first < second)
+univers mattermost compare "v8.1.5" "v10.0.0" # → -1 (first < second)
 univers pypi compare "2.0.0" "1.9.9"          # → 1 (first > second)
 univers semver compare "1.2.3" "1.2.3"        # → 0 (equal)
 
@@ -117,11 +118,14 @@ univers apache sort "2.4.41" "2.2.34" "9.0.45"
 # → "2.2.34" "2.4.41" "9.0.45"
 univers github sort "v2.0.0" "v1.0.0-beta" "v1.5.0" "2024.01.15"
 # → "2024.01.15" "v1.0.0-beta" "v1.5.0" "v2.0.0"
+univers mattermost sort "v8.1.0-rc1" "v8.1.5-esr" "v8.1.5" "v10.0.0"
+# → "v8.1.0-rc1" "v8.1.5-esr" "v8.1.5" "v10.0.0"
 
 # Check if version satisfies range (outputs true/false)
 univers cargo contains "^1.2.0" "1.2.5"       # → true
 univers apache contains ">=2.4.0" "2.4.41"    # → true
 univers github contains ">=v1.0.0" "v1.5.0"   # → true
+univers mattermost contains ">=v8.0.0" "v8.1.5" # → true
 univers maven contains "[1.0.0,2.0.0]" "1.5.0" # → true
 univers vers contains "vers:npm/>=1.2.0|<=2.0.0" "1.5.0" # → true
 univers vers contains "vers:alpine/>=1.2.0-r5" "1.2.1-r3" # → true

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alowayed/go-univers/pkg/ecosystem/gentoo"
 	"github.com/alowayed/go-univers/pkg/ecosystem/github"
 	"github.com/alowayed/go-univers/pkg/ecosystem/gomod"
+	"github.com/alowayed/go-univers/pkg/ecosystem/mattermost"
 	"github.com/alowayed/go-univers/pkg/ecosystem/maven"
 	"github.com/alowayed/go-univers/pkg/ecosystem/npm"
 	"github.com/alowayed/go-univers/pkg/ecosystem/nuget"
@@ -77,6 +78,9 @@ func run(w io.Writer, args []string) int {
 		},
 		gomod.Name: func(args []string) (string, int) {
 			return runEcosystem(&gomod.Ecosystem{}, args)
+		},
+		mattermost.Name: func(args []string) (string, int) {
+			return runEcosystem(&mattermost.Ecosystem{}, args)
 		},
 		maven.Name: func(args []string) (string, int) {
 			return runEcosystem(&maven.Ecosystem{}, args)

--- a/pkg/ecosystem/ecosystem.go
+++ b/pkg/ecosystem/ecosystem.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alowayed/go-univers/pkg/ecosystem/gentoo"
 	"github.com/alowayed/go-univers/pkg/ecosystem/github"
 	"github.com/alowayed/go-univers/pkg/ecosystem/gomod"
+	"github.com/alowayed/go-univers/pkg/ecosystem/mattermost"
 	"github.com/alowayed/go-univers/pkg/ecosystem/maven"
 	"github.com/alowayed/go-univers/pkg/ecosystem/npm"
 	"github.com/alowayed/go-univers/pkg/ecosystem/nuget"
@@ -79,6 +80,11 @@ var (
 	_ univers.Version[*gomod.Version]                        = &gomod.Version{}
 	_ univers.VersionRange[*gomod.Version]                   = &gomod.VersionRange{}
 	_ univers.Ecosystem[*gomod.Version, *gomod.VersionRange] = &gomod.Ecosystem{}
+
+	// mattermost
+	_ univers.Version[*mattermost.Version]                             = &mattermost.Version{}
+	_ univers.VersionRange[*mattermost.Version]                        = &mattermost.VersionRange{}
+	_ univers.Ecosystem[*mattermost.Version, *mattermost.VersionRange] = &mattermost.Ecosystem{}
 
 	// maven
 	_ univers.Version[*maven.Version]                        = &maven.Version{}

--- a/pkg/ecosystem/mattermost/mattermost.go
+++ b/pkg/ecosystem/mattermost/mattermost.go
@@ -1,0 +1,9 @@
+package mattermost
+
+const Name = "mattermost"
+
+type Ecosystem struct{}
+
+func (e *Ecosystem) Name() string {
+	return Name
+}

--- a/pkg/ecosystem/mattermost/mattermost_test.go
+++ b/pkg/ecosystem/mattermost/mattermost_test.go
@@ -1,0 +1,11 @@
+package mattermost
+
+import "testing"
+
+func TestEcosystem_Name(t *testing.T) {
+	e := &Ecosystem{}
+	want := "mattermost"
+	if got := e.Name(); got != want {
+		t.Errorf("Ecosystem.Name() = %v, want %v", got, want)
+	}
+}

--- a/pkg/ecosystem/mattermost/range.go
+++ b/pkg/ecosystem/mattermost/range.go
@@ -1,0 +1,125 @@
+package mattermost
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type VersionRange struct {
+	original    string
+	constraints []*constraint
+}
+
+type constraint struct {
+	operator string
+	version  *Version
+}
+
+var (
+	// Constraint pattern for individual Mattermost version constraints
+	constraintPattern = regexp.MustCompile(`^(>=|<=|>|<|=)?(.+)$`)
+)
+
+func (e *Ecosystem) NewVersionRange(rangeStr string) (*VersionRange, error) {
+	if rangeStr == "" {
+		return nil, fmt.Errorf("range string cannot be empty")
+	}
+
+	// Trim leading and trailing whitespace
+	trimmed := strings.TrimSpace(rangeStr)
+	if trimmed == "" {
+		return nil, fmt.Errorf("range string cannot be empty or only whitespace")
+	}
+
+	// Parse constraints by splitting on spaces
+	constraints, err := parseConstraints(trimmed)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VersionRange{
+		original:    rangeStr,
+		constraints: constraints,
+	}, nil
+}
+
+func parseConstraints(rangeStr string) ([]*constraint, error) {
+	// Split by spaces to handle multiple constraints
+	parts := strings.Fields(rangeStr)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("no constraints found")
+	}
+
+	var constraints []*constraint
+	ecosystem := &Ecosystem{}
+
+	for _, part := range parts {
+		constraint, err := parseConstraint(part, ecosystem)
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, constraint)
+	}
+
+	return constraints, nil
+}
+
+func parseConstraint(constraintStr string, ecosystem *Ecosystem) (*constraint, error) {
+	matches := constraintPattern.FindStringSubmatch(constraintStr)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid constraint format: %s", constraintStr)
+	}
+
+	operator := matches[1]
+	versionStr := strings.TrimSpace(matches[2])
+
+	// Default operator is "=" (exact match)
+	if operator == "" {
+		operator = "="
+	}
+
+	// Parse the version
+	version, err := ecosystem.NewVersion(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version in constraint: %s: %v", versionStr, err)
+	}
+
+	return &constraint{
+		operator: operator,
+		version:  version,
+	}, nil
+}
+
+func (r *VersionRange) Contains(version *Version) bool {
+	// All constraints must be satisfied
+	for _, constraint := range r.constraints {
+		if !constraint.matches(version) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *VersionRange) String() string {
+	return r.original
+}
+
+func (c *constraint) matches(version *Version) bool {
+	cmp := version.Compare(c.version)
+
+	switch c.operator {
+	case "=":
+		return cmp == 0
+	case ">":
+		return cmp > 0
+	case ">=":
+		return cmp >= 0
+	case "<":
+		return cmp < 0
+	case "<=":
+		return cmp <= 0
+	default:
+		return false
+	}
+}

--- a/pkg/ecosystem/mattermost/range_test.go
+++ b/pkg/ecosystem/mattermost/range_test.go
@@ -1,0 +1,347 @@
+package mattermost
+
+import (
+	"testing"
+)
+
+func TestEcosystem_NewVersionRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "exact version",
+			input: "v8.1.5",
+		},
+		{
+			name:  "greater than",
+			input: ">v8.1.0",
+		},
+		{
+			name:  "greater than or equal",
+			input: ">=v8.0.0",
+		},
+		{
+			name:  "less than",
+			input: "<v9.0.0",
+		},
+		{
+			name:  "less than or equal",
+			input: "<=v8.1.5",
+		},
+		{
+			name:  "explicit equal",
+			input: "=v8.1.5",
+		},
+		{
+			name:  "range with multiple constraints",
+			input: ">=v8.0.0 <v9.0.0",
+		},
+		{
+			name:  "range without v prefix",
+			input: ">=8.0.0 <=8.1.5",
+		},
+		{
+			name:  "ESR range",
+			input: ">=v8.1.5-esr",
+		},
+		{
+			name:  "RC range",
+			input: ">=v8.1.0-rc1",
+		},
+		// Error cases
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid version in range",
+			input:   ">=v8.1",
+			wantErr: true,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ecosystem.NewVersionRange(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Ecosystem.NewVersionRange() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.String() != tt.input {
+				t.Errorf("VersionRange.String() = %v, want %v", got.String(), tt.input)
+			}
+		})
+	}
+}
+
+func TestVersionRange_Contains(t *testing.T) {
+	tests := []struct {
+		name     string
+		rangeStr string
+		version  string
+		want     bool
+	}{
+		// Exact matches
+		{
+			name:     "exact match with v prefix",
+			rangeStr: "v8.1.5",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "exact match without prefix",
+			rangeStr: "8.1.5",
+			version:  "8.1.5",
+			want:     true,
+		},
+		{
+			name:     "exact no match",
+			rangeStr: "v8.1.5",
+			version:  "v8.1.4",
+			want:     false,
+		},
+		// Greater than
+		{
+			name:     "greater than - true",
+			rangeStr: ">v8.1.0",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "greater than - false equal",
+			rangeStr: ">v8.1.5",
+			version:  "v8.1.5",
+			want:     false,
+		},
+		{
+			name:     "greater than - false less",
+			rangeStr: ">v8.1.5",
+			version:  "v8.1.0",
+			want:     false,
+		},
+		// Greater than or equal
+		{
+			name:     "greater than or equal - true greater",
+			rangeStr: ">=v8.1.0",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "greater than or equal - true equal",
+			rangeStr: ">=v8.1.5",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "greater than or equal - false less",
+			rangeStr: ">=v8.1.5",
+			version:  "v8.1.0",
+			want:     false,
+		},
+		// Less than
+		{
+			name:     "less than - true",
+			rangeStr: "<v9.0.0",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "less than - false equal",
+			rangeStr: "<v8.1.5",
+			version:  "v8.1.5",
+			want:     false,
+		},
+		{
+			name:     "less than - false greater",
+			rangeStr: "<v8.1.0",
+			version:  "v8.1.5",
+			want:     false,
+		},
+		// Less than or equal
+		{
+			name:     "less than or equal - true less",
+			rangeStr: "<=v8.1.5",
+			version:  "v8.1.0",
+			want:     true,
+		},
+		{
+			name:     "less than or equal - true equal",
+			rangeStr: "<=v8.1.5",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "less than or equal - false greater",
+			rangeStr: "<=v8.1.0",
+			version:  "v8.1.5",
+			want:     false,
+		},
+		// Range constraints
+		{
+			name:     "range - version in range",
+			rangeStr: ">=v8.0.0 <v9.0.0",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "range - version at lower bound",
+			rangeStr: ">=v8.0.0 <v9.0.0",
+			version:  "v8.0.0",
+			want:     true,
+		},
+		{
+			name:     "range - version at upper bound",
+			rangeStr: ">=v8.0.0 <v9.0.0",
+			version:  "v9.0.0",
+			want:     false,
+		},
+		{
+			name:     "range - version below range",
+			rangeStr: ">=v8.0.0 <v9.0.0",
+			version:  "v7.8.11",
+			want:     false,
+		},
+		{
+			name:     "range - version above range",
+			rangeStr: ">=v8.0.0 <v9.0.0",
+			version:  "v10.0.0",
+			want:     false,
+		},
+		// Prefix handling
+		{
+			name:     "mixed prefix in range and version",
+			rangeStr: ">=v8.1.0",
+			version:  "8.1.5",
+			want:     true,
+		},
+		// Qualifiers
+		{
+			name:     "rc in range",
+			rangeStr: ">=v8.1.0-rc1",
+			version:  "v8.1.0",
+			want:     true,
+		},
+		{
+			name:     "release vs rc constraint",
+			rangeStr: ">=v8.1.0",
+			version:  "v8.1.0-rc1",
+			want:     false,
+		},
+		{
+			name:     "ESR in range",
+			rangeStr: ">=v8.1.5-esr",
+			version:  "v8.2.0",
+			want:     true,
+		},
+		{
+			name:     "rc vs ESR constraint",
+			rangeStr: ">=v8.1.0-rc1",
+			version:  "v8.1.5-esr",
+			want:     true,
+		},
+		// Real Mattermost scenarios
+		{
+			name:     "Mattermost 8.x series range",
+			rangeStr: ">=v8.0.0 <v9.0.0",
+			version:  "v8.1.5",
+			want:     true,
+		},
+		{
+			name:     "Mattermost ESR constraint",
+			rangeStr: ">=v8.1.5-esr",
+			version:  "v8.1.5-esr",
+			want:     true,
+		},
+		{
+			name:     "Mattermost RC progression",
+			rangeStr: ">=v8.1.0-rc1",
+			version:  "v8.1.0-rc2",
+			want:     true,
+		},
+		{
+			name:     "Cross-major version check",
+			rangeStr: ">=v10.0.0",
+			version:  "v10.11.2",
+			want:     true,
+		},
+		{
+			name:     "ESR vs newer major",
+			rangeStr: ">=v8.1.5-esr",
+			version:  "v10.0.0",
+			want:     true,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vr, err := ecosystem.NewVersionRange(tt.rangeStr)
+			if err != nil {
+				t.Fatalf("Failed to parse range %s: %v", tt.rangeStr, err)
+			}
+
+			v, err := ecosystem.NewVersion(tt.version)
+			if err != nil {
+				t.Fatalf("Failed to parse version %s: %v", tt.version, err)
+			}
+
+			got := vr.Contains(v)
+			if got != tt.want {
+				t.Errorf("VersionRange.Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionRange_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "simple range",
+			input: ">=v8.0.0",
+		},
+		{
+			name:  "complex range",
+			input: ">=v8.0.0 <v9.0.0",
+		},
+		{
+			name:  "exact version",
+			input: "v8.1.5",
+		},
+		{
+			name:  "ESR range",
+			input: ">=v8.1.5-esr",
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vr, err := ecosystem.NewVersionRange(tt.input)
+			if err != nil {
+				t.Fatalf("Failed to parse range %s: %v", tt.input, err)
+			}
+
+			if got := vr.String(); got != tt.input {
+				t.Errorf("VersionRange.String() = %v, want %v", got, tt.input)
+			}
+		})
+	}
+}

--- a/pkg/ecosystem/mattermost/version.go
+++ b/pkg/ecosystem/mattermost/version.go
@@ -1,0 +1,160 @@
+package mattermost
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	original  string
+	prefix    string // v, etc.
+	major     int
+	minor     int
+	patch     int
+	qualifier string // esr, rc, etc.
+	number    int    // for rc1, rc2, etc.
+}
+
+var (
+	// Mattermost version pattern supports:
+	// - Semantic with v prefix: v8.1.5, v10.12.0
+	// - Semantic without prefix: 8.1.5, 10.12.0
+	// - ESR versions: v8.1.5-esr, 8.1.5-esr
+	// - Release candidates: v8.1.0-rc1, v10.12.0-rc2
+	mattermostVersionPattern = regexp.MustCompile(`^(v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(esr|rc)(\d*))?$`)
+)
+
+func (e *Ecosystem) NewVersion(version string) (*Version, error) {
+	if version == "" {
+		return nil, fmt.Errorf("version string cannot be empty")
+	}
+
+	// Trim leading and trailing whitespace
+	trimmed := strings.TrimSpace(version)
+	if trimmed == "" {
+		return nil, fmt.Errorf("version string cannot be empty or only whitespace")
+	}
+
+	// Parse Mattermost version pattern
+	matches := mattermostVersionPattern.FindStringSubmatch(trimmed)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid Mattermost version format: %s", trimmed)
+	}
+
+	return parseSemanticVersion(trimmed, matches)
+}
+
+func parseSemanticVersion(original string, matches []string) (*Version, error) {
+	prefix := matches[1]
+
+	// Parse major version
+	major, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid major version: %s", matches[2])
+	}
+
+	// Parse minor version
+	minor, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return nil, fmt.Errorf("invalid minor version: %s", matches[3])
+	}
+
+	// Parse patch version
+	patch, err := strconv.Atoi(matches[4])
+	if err != nil {
+		return nil, fmt.Errorf("invalid patch version: %s", matches[4])
+	}
+
+	// Parse optional qualifier (esr, rc, etc.)
+	qualifier := ""
+	number := 0
+	if matches[5] != "" {
+		qualifier = strings.ToLower(matches[5])
+		if matches[6] != "" {
+			number, err = strconv.Atoi(matches[6])
+			if err != nil {
+				return nil, fmt.Errorf("invalid qualifier number: %s", matches[6])
+			}
+		}
+	}
+
+	return &Version{
+		original:  original,
+		prefix:    prefix,
+		major:     major,
+		minor:     minor,
+		patch:     patch,
+		qualifier: qualifier,
+		number:    number,
+	}, nil
+}
+
+func (v *Version) Compare(other *Version) int {
+	// Compare major.minor.patch first
+	if v.major != other.major {
+		return compareInt(v.major, other.major)
+	}
+	if v.minor != other.minor {
+		return compareInt(v.minor, other.minor)
+	}
+	if v.patch != other.patch {
+		return compareInt(v.patch, other.patch)
+	}
+
+	// Compare qualifiers
+	return compareQualifiers(v.qualifier, v.number, other.qualifier, other.number)
+}
+
+func (v *Version) String() string {
+	return v.original
+}
+
+// compareQualifiers compares Mattermost version qualifiers following precedence
+func compareQualifiers(q1 string, n1 int, q2 string, n2 int) int {
+	// No qualifier (release) is higher than any qualifier
+	if q1 == "" && q2 == "" {
+		return 0
+	}
+	if q1 == "" {
+		return 1 // Release > any qualifier
+	}
+	if q2 == "" {
+		return -1 // Any qualifier < release
+	}
+
+	// Both have qualifiers - compare by precedence
+	p1 := getQualifierPrecedence(q1)
+	p2 := getQualifierPrecedence(q2)
+
+	if p1 != p2 {
+		return compareInt(p1, p2)
+	}
+
+	// Same qualifier type, compare numbers
+	return compareInt(n1, n2)
+}
+
+// getQualifierPrecedence returns precedence value for Mattermost qualifiers
+// Lower values have lower precedence (come first in ordering)
+func getQualifierPrecedence(qualifier string) int {
+	switch qualifier {
+	case "rc":
+		return 1
+	case "esr":
+		return 2
+	default:
+		return 99 // Unknown qualifiers come last
+	}
+}
+
+func compareInt(a, b int) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/ecosystem/mattermost/version_test.go
+++ b/pkg/ecosystem/mattermost/version_test.go
@@ -1,0 +1,378 @@
+package mattermost
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEcosystem_NewVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Version
+		wantErr bool
+	}{
+		// Semantic versions with v prefix
+		{
+			name:  "Mattermost semantic v8.1.5",
+			input: "v8.1.5",
+			want: &Version{
+				original: "v8.1.5",
+				prefix:   "v",
+				major:    8,
+				minor:    1,
+				patch:    5,
+			},
+		},
+		{
+			name:  "Mattermost semantic v10.12.0",
+			input: "v10.12.0",
+			want: &Version{
+				original: "v10.12.0",
+				prefix:   "v",
+				major:    10,
+				minor:    12,
+				patch:    0,
+			},
+		},
+		// Semantic versions without prefix
+		{
+			name:  "Mattermost semantic 8.1.5",
+			input: "8.1.5",
+			want: &Version{
+				original: "8.1.5",
+				prefix:   "",
+				major:    8,
+				minor:    1,
+				patch:    5,
+			},
+		},
+		{
+			name:  "Mattermost semantic 10.12.0",
+			input: "10.12.0",
+			want: &Version{
+				original: "10.12.0",
+				prefix:   "",
+				major:    10,
+				minor:    12,
+				patch:    0,
+			},
+		},
+		// ESR versions
+		{
+			name:  "Mattermost ESR v8.1.5-esr",
+			input: "v8.1.5-esr",
+			want: &Version{
+				original:  "v8.1.5-esr",
+				prefix:    "v",
+				major:     8,
+				minor:     1,
+				patch:     5,
+				qualifier: "esr",
+				number:    0,
+			},
+		},
+		{
+			name:  "Mattermost ESR 7.8.11-esr",
+			input: "7.8.11-esr",
+			want: &Version{
+				original:  "7.8.11-esr",
+				prefix:    "",
+				major:     7,
+				minor:     8,
+				patch:     11,
+				qualifier: "esr",
+				number:    0,
+			},
+		},
+		// Release candidates
+		{
+			name:  "Mattermost RC v8.1.0-rc1",
+			input: "v8.1.0-rc1",
+			want: &Version{
+				original:  "v8.1.0-rc1",
+				prefix:    "v",
+				major:     8,
+				minor:     1,
+				patch:     0,
+				qualifier: "rc",
+				number:    1,
+			},
+		},
+		{
+			name:  "Mattermost RC v10.12.0-rc2",
+			input: "v10.12.0-rc2",
+			want: &Version{
+				original:  "v10.12.0-rc2",
+				prefix:    "v",
+				major:     10,
+				minor:     12,
+				patch:     0,
+				qualifier: "rc",
+				number:    2,
+			},
+		},
+		{
+			name:  "Mattermost RC 8.1.0-rc",
+			input: "8.1.0-rc",
+			want: &Version{
+				original:  "8.1.0-rc",
+				prefix:    "",
+				major:     8,
+				minor:     1,
+				patch:     0,
+				qualifier: "rc",
+				number:    0,
+			},
+		},
+		// Real Mattermost examples
+		{
+			name:  "Mattermost current v10.11.2",
+			input: "v10.11.2",
+			want: &Version{
+				original: "v10.11.2",
+				prefix:   "v",
+				major:    10,
+				minor:    11,
+				patch:    2,
+			},
+		},
+		{
+			name:  "Mattermost v9.5.10",
+			input: "v9.5.10",
+			want: &Version{
+				original: "v9.5.10",
+				prefix:   "v",
+				major:    9,
+				minor:    5,
+				patch:    10,
+			},
+		},
+		// Error cases
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - no patch",
+			input:   "v8.1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - no minor",
+			input:   "v8",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - letters in version numbers",
+			input:   "v8.a.3",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - unsupported qualifier",
+			input:   "v8.1.0-alpha",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - multiple qualifiers",
+			input:   "v8.1.0-rc1-esr",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - leading zeros",
+			input:   "v08.01.05",
+			wantErr: true,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ecosystem.NewVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Ecosystem.NewVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Ecosystem.NewVersion() got = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersion_Compare(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   string
+		v2   string
+		want int
+	}{
+		// Basic semantic comparisons
+		{
+			name: "same version",
+			v1:   "v8.1.5",
+			v2:   "v8.1.5",
+			want: 0,
+		},
+		{
+			name: "major version difference",
+			v1:   "v8.1.0",
+			v2:   "v9.0.0",
+			want: -1,
+		},
+		{
+			name: "minor version difference",
+			v1:   "v8.1.0",
+			v2:   "v8.2.0",
+			want: -1,
+		},
+		{
+			name: "patch version difference",
+			v1:   "v8.1.1",
+			v2:   "v8.1.2",
+			want: -1,
+		},
+		// Prefix handling
+		{
+			name: "v prefix vs no prefix same version",
+			v1:   "v8.1.5",
+			v2:   "8.1.5",
+			want: 0,
+		},
+		// Qualifier comparisons
+		{
+			name: "release vs rc",
+			v1:   "v8.1.0",
+			v2:   "v8.1.0-rc1",
+			want: 1,
+		},
+		{
+			name: "release vs esr",
+			v1:   "v8.1.5",
+			v2:   "v8.1.5-esr",
+			want: 1,
+		},
+		{
+			name: "rc vs esr",
+			v1:   "v8.1.0-rc1",
+			v2:   "v8.1.5-esr",
+			want: -1, // rc < esr in precedence
+		},
+		{
+			name: "numbered rc versions",
+			v1:   "v8.1.0-rc1",
+			v2:   "v8.1.0-rc2",
+			want: -1,
+		},
+		{
+			name: "rc with and without number",
+			v1:   "v8.1.0-rc",
+			v2:   "v8.1.0-rc1",
+			want: -1,
+		},
+		// Real Mattermost scenarios
+		{
+			name: "Mattermost 10.x series",
+			v1:   "v10.11.0",
+			v2:   "v10.11.2",
+			want: -1,
+		},
+		{
+			name: "Mattermost ESR comparison",
+			v1:   "v8.1.5-esr",
+			v2:   "v7.8.11-esr",
+			want: 1,
+		},
+		{
+			name: "Mattermost RC to release",
+			v1:   "v10.12.0-rc1",
+			v2:   "v10.12.0",
+			want: -1,
+		},
+		{
+			name: "Cross-major versions",
+			v1:   "v9.5.10",
+			v2:   "v10.0.0",
+			want: -1,
+		},
+		{
+			name: "ESR vs newer release",
+			v1:   "v8.1.5-esr",
+			v2:   "v9.0.0",
+			want: -1,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v1, err := ecosystem.NewVersion(tt.v1)
+			if err != nil {
+				t.Fatalf("Failed to parse v1 %s: %v", tt.v1, err)
+			}
+			v2, err := ecosystem.NewVersion(tt.v2)
+			if err != nil {
+				t.Fatalf("Failed to parse v2 %s: %v", tt.v2, err)
+			}
+
+			got := v1.Compare(v2)
+			if got != tt.want {
+				t.Errorf("Version.Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "semantic version with v prefix",
+			input: "v8.1.5",
+		},
+		{
+			name:  "semantic version without prefix",
+			input: "8.1.5",
+		},
+		{
+			name:  "ESR version",
+			input: "v8.1.5-esr",
+		},
+		{
+			name:  "release candidate",
+			input: "v8.1.0-rc1",
+		},
+		{
+			name:  "double digit versions",
+			input: "v10.12.0",
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := ecosystem.NewVersion(tt.input)
+			if err != nil {
+				t.Fatalf("Failed to parse version %s: %v", tt.input, err)
+			}
+
+			if got := v.String(); got != tt.input {
+				t.Errorf("Version.String() = %v, want %v", got, tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Mattermost ecosystem support as requested in #87
- Follows semantic versioning with Mattermost-specific extensions (ESR, RC)
- Provides comprehensive version parsing, comparison, and range operations

## Features
- Standard releases: `v8.1.5`, `10.12.0`
- ESR versions: `v8.1.5-esr`
- Release candidates: `v8.1.0-rc1`, `v10.12.0-rc2`
- Version ranges with standard operators: `>=v8.0.0 <v9.0.0`
- CLI integration with compare, sort, and contains commands

## Test Coverage
- 55+ comprehensive test cases covering all version patterns
- Table-driven tests following project conventions
- Interface compliance verification
- CLI functionality validation

## Integration
- Added to CLI ecosystem registry
- Interface compliance checks in ecosystem.go
- README documentation with usage examples
- All quality checks passing (fmt, vet, golangci-lint)

🤖 Generated with [Claude Code](https://claude.ai/code)