### PR TITLE
feat: add Hex ecosystem support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ func main() {
 | **Gentoo** | `pkg/ecosystem/gentoo` | [`ebuild` ❌](https://github.com/alowayed/go-univers/issues/70) |
 | **GitHub** | `pkg/ecosystem/github` | [`github` ❌](https://github.com/alowayed/go-univers/issues/78) |
 | **Go** | `pkg/ecosystem/gomod` | `golang` ✅ |
-| **Hex (Elixir)** | [❌](https://github.com/alowayed/go-univers/issues/79) | [`hex` ❌](https://github.com/alowayed/go-univers/issues/80) |
+| **Hex** | `pkg/ecosystem/hex` | [`hex` ❌](https://github.com/alowayed/go-univers/issues/80) |
 | **Intdot** | [❌](https://github.com/alowayed/go-univers/issues/89) | [`intdot` ❌](https://github.com/alowayed/go-univers/issues/90) |
 | **Mattermost** | `pkg/ecosystem/mattermost` | [`mattermost` ❌](https://github.com/alowayed/go-univers/issues/88) |
 | **Maven** | `pkg/ecosystem/maven` | `maven` ✅ |
@@ -107,6 +107,7 @@ The CLI follows the pattern: `univers <ecosystem|spec> <command> [args]`
 univers npm compare "1.2.3" "1.2.4"           # → -1 (first < second)
 univers apache compare "2.4.40" "2.4.41"      # → -1 (first < second)
 univers github compare "v1.0.0" "v1.0.1"      # → -1 (first < second)
+univers hex compare "1.7.9" "1.7.10"          # → -1 (first < second)
 univers mattermost compare "v8.1.5" "v10.0.0" # → -1 (first < second)
 univers pypi compare "2.0.0" "1.9.9"          # → 1 (first > second)
 univers semver compare "1.2.3" "1.2.3"        # → 0 (equal)
@@ -118,6 +119,8 @@ univers apache sort "2.4.41" "2.2.34" "9.0.45"
 # → "2.2.34" "2.4.41" "9.0.45"
 univers github sort "v2.0.0" "v1.0.0-beta" "v1.5.0" "2024.01.15"
 # → "2024.01.15" "v1.0.0-beta" "v1.5.0" "v2.0.0"
+univers hex sort "1.0.0-alpha.1" "1.0.0-rc.1" "1.0.0" "1.1.0"
+# → "1.0.0-alpha.1" "1.0.0-rc.1" "1.0.0" "1.1.0"
 univers mattermost sort "v8.1.0-rc1" "v8.1.5-esr" "v8.1.5" "v10.0.0"
 # → "v8.1.0-rc1" "v8.1.5-esr" "v8.1.5" "v10.0.0"
 
@@ -125,6 +128,7 @@ univers mattermost sort "v8.1.0-rc1" "v8.1.5-esr" "v8.1.5" "v10.0.0"
 univers cargo contains "^1.2.0" "1.2.5"       # → true
 univers apache contains ">=2.4.0" "2.4.41"    # → true
 univers github contains ">=v1.0.0" "v1.5.0"   # → true
+univers hex contains "~>1.7.0" "1.7.10"       # → true
 univers mattermost contains ">=v8.0.0" "v8.1.5" # → true
 univers maven contains "[1.0.0,2.0.0]" "1.5.0" # → true
 univers vers contains "vers:npm/>=1.2.0|<=2.0.0" "1.5.0" # → true

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alowayed/go-univers/pkg/ecosystem/gentoo"
 	"github.com/alowayed/go-univers/pkg/ecosystem/github"
 	"github.com/alowayed/go-univers/pkg/ecosystem/gomod"
+	"github.com/alowayed/go-univers/pkg/ecosystem/hex"
 	"github.com/alowayed/go-univers/pkg/ecosystem/mattermost"
 	"github.com/alowayed/go-univers/pkg/ecosystem/maven"
 	"github.com/alowayed/go-univers/pkg/ecosystem/npm"
@@ -78,6 +79,9 @@ func run(w io.Writer, args []string) int {
 		},
 		gomod.Name: func(args []string) (string, int) {
 			return runEcosystem(&gomod.Ecosystem{}, args)
+		},
+		hex.Name: func(args []string) (string, int) {
+			return runEcosystem(&hex.Ecosystem{}, args)
 		},
 		mattermost.Name: func(args []string) (string, int) {
 			return runEcosystem(&mattermost.Ecosystem{}, args)

--- a/pkg/ecosystem/ecosystem.go
+++ b/pkg/ecosystem/ecosystem.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alowayed/go-univers/pkg/ecosystem/gentoo"
 	"github.com/alowayed/go-univers/pkg/ecosystem/github"
 	"github.com/alowayed/go-univers/pkg/ecosystem/gomod"
+	"github.com/alowayed/go-univers/pkg/ecosystem/hex"
 	"github.com/alowayed/go-univers/pkg/ecosystem/mattermost"
 	"github.com/alowayed/go-univers/pkg/ecosystem/maven"
 	"github.com/alowayed/go-univers/pkg/ecosystem/npm"
@@ -80,6 +81,11 @@ var (
 	_ univers.Version[*gomod.Version]                        = &gomod.Version{}
 	_ univers.VersionRange[*gomod.Version]                   = &gomod.VersionRange{}
 	_ univers.Ecosystem[*gomod.Version, *gomod.VersionRange] = &gomod.Ecosystem{}
+
+	// hex
+	_ univers.Version[*hex.Version]                      = &hex.Version{}
+	_ univers.VersionRange[*hex.Version]                 = &hex.VersionRange{}
+	_ univers.Ecosystem[*hex.Version, *hex.VersionRange] = &hex.Ecosystem{}
 
 	// mattermost
 	_ univers.Version[*mattermost.Version]                             = &mattermost.Version{}

--- a/pkg/ecosystem/hex/hex.go
+++ b/pkg/ecosystem/hex/hex.go
@@ -1,0 +1,9 @@
+package hex
+
+const Name = "hex"
+
+type Ecosystem struct{}
+
+func (e *Ecosystem) Name() string {
+	return Name
+}

--- a/pkg/ecosystem/hex/hex_test.go
+++ b/pkg/ecosystem/hex/hex_test.go
@@ -1,0 +1,11 @@
+package hex
+
+import "testing"
+
+func TestEcosystem_Name(t *testing.T) {
+	e := &Ecosystem{}
+	want := "hex"
+	if got := e.Name(); got != want {
+		t.Errorf("Ecosystem.Name() = %v, want %v", got, want)
+	}
+}

--- a/pkg/ecosystem/hex/range.go
+++ b/pkg/ecosystem/hex/range.go
@@ -1,0 +1,185 @@
+package hex
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type VersionRange struct {
+	original    string
+	constraints []*constraint
+}
+
+type constraint struct {
+	operator string
+	version  *Version
+}
+
+var (
+	// Constraint pattern for Hex version constraints
+	// Supports: >=, <=, >, <, =, ~> (pessimistic operator)
+	constraintPattern = regexp.MustCompile(`^(>=|<=|>|<|=|~>)?(.+)$`)
+)
+
+func (e *Ecosystem) NewVersionRange(rangeStr string) (*VersionRange, error) {
+	if rangeStr == "" {
+		return nil, fmt.Errorf("range string cannot be empty")
+	}
+
+	// Trim leading and trailing whitespace
+	trimmed := strings.TrimSpace(rangeStr)
+	if trimmed == "" {
+		return nil, fmt.Errorf("range string cannot be empty or only whitespace")
+	}
+
+	// Parse constraints by splitting on spaces or "and" keywords
+	constraints, err := parseConstraints(trimmed, e)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VersionRange{
+		original:    rangeStr,
+		constraints: constraints,
+	}, nil
+}
+
+func parseConstraints(rangeStr string, ecosystem *Ecosystem) ([]*constraint, error) {
+	// Split by spaces and "and" keywords to handle multiple constraints
+	parts := strings.Fields(rangeStr)
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("no constraints found")
+	}
+
+	var constraints []*constraint
+
+	for _, part := range parts {
+		// Skip "and" keywords
+		if strings.ToLower(part) == "and" {
+			continue
+		}
+
+		constraint, err := parseConstraint(part, ecosystem)
+		if err != nil {
+			return nil, err
+		}
+
+		// Handle pessimistic operator (~>) by converting to range
+		if constraint.operator == "~>" {
+			pessimisticConstraints := expandPessimisticConstraint(constraint)
+			constraints = append(constraints, pessimisticConstraints...)
+		} else {
+			constraints = append(constraints, constraint)
+		}
+	}
+
+	return constraints, nil
+}
+
+func parseConstraint(constraintStr string, ecosystem *Ecosystem) (*constraint, error) {
+	matches := constraintPattern.FindStringSubmatch(constraintStr)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid constraint format: %s", constraintStr)
+	}
+
+	operator := matches[1]
+	versionStr := strings.TrimSpace(matches[2])
+
+	// Default operator is "=" (exact match)
+	if operator == "" {
+		operator = "="
+	}
+
+	// Parse the version
+	version, err := ecosystem.NewVersion(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version in constraint: %s: %v", versionStr, err)
+	}
+
+	return &constraint{
+		operator: operator,
+		version:  version,
+	}, nil
+}
+
+// expandPessimisticConstraint converts ~> operator to equivalent >= and < constraints
+// Standard pessimistic operator behavior:
+// ~> 1.2.3 means >= 1.2.3 and < 1.3.0 (increment minor)
+// ~> 1.2.0 means >= 1.2.0 and < 1.3.0 (increment minor)
+// ~> 1.14 means >= 1.14.0 and < 2.0.0 (increment major for partial version)
+func expandPessimisticConstraint(c *constraint) []*constraint {
+	v := c.version
+
+	// Create >= constraint with full version (ensuring patch is present)
+	lowerVersion := &Version{
+		original: fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch),
+		major:    v.major,
+		minor:    v.minor,
+		patch:    v.patch,
+	}
+	geConstraint := &constraint{
+		operator: ">=",
+		version:  lowerVersion,
+	}
+
+	// Determine upper bound
+	var upperBound *Version
+	if strings.Count(v.original, ".") == 1 {
+		// Partial version like "1.14" - increment major
+		upperBound = &Version{
+			original: fmt.Sprintf("%d.0.0", v.major+1),
+			major:    v.major + 1,
+			minor:    0,
+			patch:    0,
+		}
+	} else {
+		// Full version like "1.2.3" or "1.2.0" - increment minor
+		upperBound = &Version{
+			original: fmt.Sprintf("%d.%d.0", v.major, v.minor+1),
+			major:    v.major,
+			minor:    v.minor + 1,
+			patch:    0,
+		}
+	}
+
+	ltConstraint := &constraint{
+		operator: "<",
+		version:  upperBound,
+	}
+
+	return []*constraint{geConstraint, ltConstraint}
+}
+
+func (r *VersionRange) Contains(version *Version) bool {
+	// All constraints must be satisfied
+	for _, constraint := range r.constraints {
+		if !constraint.matches(version) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *VersionRange) String() string {
+	return r.original
+}
+
+func (c *constraint) matches(version *Version) bool {
+	cmp := version.Compare(c.version)
+
+	switch c.operator {
+	case "=":
+		return cmp == 0
+	case ">":
+		return cmp > 0
+	case ">=":
+		return cmp >= 0
+	case "<":
+		return cmp < 0
+	case "<=":
+		return cmp <= 0
+	default:
+		return false
+	}
+}

--- a/pkg/ecosystem/hex/range_test.go
+++ b/pkg/ecosystem/hex/range_test.go
@@ -323,10 +323,35 @@ func TestVersionRange_Contains(t *testing.T) {
 			want:     true,
 		},
 		{
-			name:     "Elixir compatibility",
+			name:     "Elixir compatibility - out of range",
 			rangeStr: "~>1.14",
 			version:  "1.15.7",
+			want:     false,
+		},
+		{
+			name:     "Elixir compatibility - in range",
+			rangeStr: "~>1.14",
+			version:  "1.14.3",
 			want:     true,
+		},
+		// Pessimistic operator with pre-release identifiers
+		{
+			name:     "pessimistic with pre-release - exact match",
+			rangeStr: "~>1.0.0-alpha",
+			version:  "1.0.0-alpha",
+			want:     true,
+		},
+		{
+			name:     "pessimistic with pre-release - in range",
+			rangeStr: "~>1.0.0-alpha",
+			version:  "1.0.1",
+			want:     true,
+		},
+		{
+			name:     "pessimistic with pre-release - out of range",
+			rangeStr: "~>1.0.0-alpha",
+			version:  "1.1.0",
+			want:     false,
 		},
 	}
 

--- a/pkg/ecosystem/hex/range_test.go
+++ b/pkg/ecosystem/hex/range_test.go
@@ -1,0 +1,392 @@
+package hex
+
+import (
+	"testing"
+)
+
+func TestEcosystem_NewVersionRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "exact version",
+			input: "1.0.0",
+		},
+		{
+			name:  "greater than",
+			input: ">1.0.0",
+		},
+		{
+			name:  "greater than or equal",
+			input: ">=1.0.0",
+		},
+		{
+			name:  "less than",
+			input: "<2.0.0",
+		},
+		{
+			name:  "less than or equal",
+			input: "<=1.5.0",
+		},
+		{
+			name:  "explicit equal",
+			input: "=1.0.0",
+		},
+		{
+			name:  "pessimistic operator patch",
+			input: "~>1.2.3",
+		},
+		{
+			name:  "pessimistic operator minor",
+			input: "~>1.2.0",
+		},
+		{
+			name:  "pessimistic operator major",
+			input: "~>1.0",
+		},
+		{
+			name:  "range with multiple constraints",
+			input: ">=1.0.0 <2.0.0",
+		},
+		{
+			name:  "pre-release range",
+			input: ">=1.0.0-alpha",
+		},
+		{
+			name:  "complex range",
+			input: ">=1.2.3 <1.3.0",
+		},
+		// Error cases
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid version in range",
+			input:   ">=1.2.a",
+			wantErr: true,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ecosystem.NewVersionRange(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Ecosystem.NewVersionRange() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.String() != tt.input {
+				t.Errorf("VersionRange.String() = %v, want %v", got.String(), tt.input)
+			}
+		})
+	}
+}
+
+func TestVersionRange_Contains(t *testing.T) {
+	tests := []struct {
+		name     string
+		rangeStr string
+		version  string
+		want     bool
+	}{
+		// Exact matches
+		{
+			name:     "exact match",
+			rangeStr: "1.0.0",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "exact no match",
+			rangeStr: "1.0.0",
+			version:  "1.0.1",
+			want:     false,
+		},
+		// Greater than
+		{
+			name:     "greater than - true",
+			rangeStr: ">1.0.0",
+			version:  "1.0.1",
+			want:     true,
+		},
+		{
+			name:     "greater than - false equal",
+			rangeStr: ">1.0.0",
+			version:  "1.0.0",
+			want:     false,
+		},
+		{
+			name:     "greater than - false less",
+			rangeStr: ">1.0.1",
+			version:  "1.0.0",
+			want:     false,
+		},
+		// Greater than or equal
+		{
+			name:     "greater than or equal - true greater",
+			rangeStr: ">=1.0.0",
+			version:  "1.0.1",
+			want:     true,
+		},
+		{
+			name:     "greater than or equal - true equal",
+			rangeStr: ">=1.0.0",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "greater than or equal - false less",
+			rangeStr: ">=1.0.1",
+			version:  "1.0.0",
+			want:     false,
+		},
+		// Less than
+		{
+			name:     "less than - true",
+			rangeStr: "<2.0.0",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "less than - false equal",
+			rangeStr: "<1.0.0",
+			version:  "1.0.0",
+			want:     false,
+		},
+		{
+			name:     "less than - false greater",
+			rangeStr: "<1.0.0",
+			version:  "1.0.1",
+			want:     false,
+		},
+		// Less than or equal
+		{
+			name:     "less than or equal - true less",
+			rangeStr: "<=1.0.1",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "less than or equal - true equal",
+			rangeStr: "<=1.0.0",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "less than or equal - false greater",
+			rangeStr: "<=1.0.0",
+			version:  "1.0.1",
+			want:     false,
+		},
+		// Pessimistic operator
+		{
+			name:     "pessimistic patch level - in range",
+			rangeStr: "~>1.2.3",
+			version:  "1.2.5",
+			want:     true,
+		},
+		{
+			name:     "pessimistic patch level - at boundary",
+			rangeStr: "~>1.2.3",
+			version:  "1.2.3",
+			want:     true,
+		},
+		{
+			name:     "pessimistic patch level - out of range minor",
+			rangeStr: "~>1.2.3",
+			version:  "1.3.0",
+			want:     false,
+		},
+		{
+			name:     "pessimistic patch level - out of range major",
+			rangeStr: "~>1.2.3",
+			version:  "2.0.0",
+			want:     false,
+		},
+		{
+			name:     "pessimistic minor level - in range",
+			rangeStr: "~>1.2.0",
+			version:  "1.2.5",
+			want:     true,
+		},
+		{
+			name:     "pessimistic minor level - out of range",
+			rangeStr: "~>1.2.0",
+			version:  "1.3.0",
+			want:     false,
+		},
+		{
+			name:     "pessimistic major level - in range",
+			rangeStr: "~>1.0.0",
+			version:  "1.0.5",
+			want:     true,
+		},
+		{
+			name:     "pessimistic major level - out of range",
+			rangeStr: "~>1.0.0",
+			version:  "2.0.0",
+			want:     false,
+		},
+		// Range constraints
+		{
+			name:     "range - version in range",
+			rangeStr: ">=1.0.0 <2.0.0",
+			version:  "1.5.0",
+			want:     true,
+		},
+		{
+			name:     "range - version at lower bound",
+			rangeStr: ">=1.0.0 <2.0.0",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "range - version at upper bound",
+			rangeStr: ">=1.0.0 <2.0.0",
+			version:  "2.0.0",
+			want:     false,
+		},
+		{
+			name:     "range - version below range",
+			rangeStr: ">=1.0.0 <2.0.0",
+			version:  "0.9.0",
+			want:     false,
+		},
+		{
+			name:     "range - version above range",
+			rangeStr: ">=1.0.0 <2.0.0",
+			version:  "2.1.0",
+			want:     false,
+		},
+		// Pre-release handling
+		{
+			name:     "pre-release in range",
+			rangeStr: ">=1.0.0-alpha",
+			version:  "1.0.0",
+			want:     true,
+		},
+		{
+			name:     "release vs pre-release constraint",
+			rangeStr: ">=1.0.0",
+			version:  "1.0.0-alpha",
+			want:     false,
+		},
+		{
+			name:     "pre-release to pre-release",
+			rangeStr: ">=1.0.0-alpha",
+			version:  "1.0.0-beta",
+			want:     true,
+		},
+		// Build metadata (ignored in comparisons)
+		{
+			name:     "build metadata ignored",
+			rangeStr: "1.0.0",
+			version:  "1.0.0+build.123",
+			want:     true,
+		},
+		{
+			name:     "both have build metadata",
+			rangeStr: "1.0.0+build.1",
+			version:  "1.0.0+build.2",
+			want:     true,
+		},
+		// Real Hex scenarios
+		{
+			name:     "Phoenix version range",
+			rangeStr: "~>1.7.0",
+			version:  "1.7.10",
+			want:     true,
+		},
+		{
+			name:     "Ecto version range",
+			rangeStr: ">=3.0.0 <4.0.0",
+			version:  "3.10.3",
+			want:     true,
+		},
+		{
+			name:     "Pre-release Phoenix",
+			rangeStr: "~>1.8.0",
+			version:  "1.8.1",
+			want:     true,
+		},
+		{
+			name:     "Elixir compatibility",
+			rangeStr: "~>1.14",
+			version:  "1.15.7",
+			want:     true,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vr, err := ecosystem.NewVersionRange(tt.rangeStr)
+			if err != nil {
+				t.Fatalf("Failed to parse range %s: %v", tt.rangeStr, err)
+			}
+
+			v, err := ecosystem.NewVersion(tt.version)
+			if err != nil {
+				t.Fatalf("Failed to parse version %s: %v", tt.version, err)
+			}
+
+			got := vr.Contains(v)
+			if got != tt.want {
+				t.Errorf("VersionRange.Contains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionRange_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "simple range",
+			input: ">=1.0.0",
+		},
+		{
+			name:  "complex range",
+			input: ">=1.0.0 <2.0.0",
+		},
+		{
+			name:  "exact version",
+			input: "1.0.0",
+		},
+		{
+			name:  "pessimistic range",
+			input: "~>1.2.3",
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vr, err := ecosystem.NewVersionRange(tt.input)
+			if err != nil {
+				t.Fatalf("Failed to parse range %s: %v", tt.input, err)
+			}
+
+			if got := vr.String(); got != tt.input {
+				t.Errorf("VersionRange.String() = %v, want %v", got, tt.input)
+			}
+		})
+	}
+}

--- a/pkg/ecosystem/hex/version.go
+++ b/pkg/ecosystem/hex/version.go
@@ -1,0 +1,217 @@
+package hex
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	original      string
+	major         int
+	minor         int
+	patch         int
+	preRelease    []string // pre-release identifiers
+	buildMetadata string   // build metadata (ignored in comparisons)
+}
+
+var (
+	// Simple Hex version pattern - much more readable and maintainable
+	// Format: MAJOR.MINOR.PATCH with optional pre-release and build metadata
+	// Examples: 1.0.0, 2.1.3-alpha.1, 1.0.0+build.1
+	hexVersionPattern = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9\-\.]+))?(?:\+([a-zA-Z0-9\-\.]+))?$`)
+	// Partial version for pessimistic operator: MAJOR.MINOR
+	hexPartialVersionPattern = regexp.MustCompile(`^(\d+)\.(\d+)$`)
+)
+
+func (e *Ecosystem) NewVersion(version string) (*Version, error) {
+	if version == "" {
+		return nil, fmt.Errorf("version string cannot be empty")
+	}
+
+	// Trim leading and trailing whitespace
+	trimmed := strings.TrimSpace(version)
+	if trimmed == "" {
+		return nil, fmt.Errorf("version string cannot be empty or only whitespace")
+	}
+
+	// Try full semantic version pattern first
+	matches := hexVersionPattern.FindStringSubmatch(trimmed)
+	if matches != nil {
+		return parseSemanticVersion(trimmed, matches)
+	}
+
+	// Try partial version pattern (for pessimistic operator)
+	partialMatches := hexPartialVersionPattern.FindStringSubmatch(trimmed)
+	if partialMatches != nil {
+		return parsePartialVersion(trimmed, partialMatches)
+	}
+
+	return nil, fmt.Errorf("invalid Hex version format: %s", trimmed)
+}
+
+func parseSemanticVersion(original string, matches []string) (*Version, error) {
+	// Parse major version
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid major version: %s", matches[1])
+	}
+
+	// Parse minor version
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid minor version: %s", matches[2])
+	}
+
+	// Parse patch version
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return nil, fmt.Errorf("invalid patch version: %s", matches[3])
+	}
+
+	// Parse optional pre-release identifiers
+	var preRelease []string
+	if matches[4] != "" {
+		preRelease = strings.Split(matches[4], ".")
+		// Validate pre-release identifiers
+		for _, identifier := range preRelease {
+			if identifier == "" {
+				return nil, fmt.Errorf("invalid pre-release identifier: empty identifier")
+			}
+		}
+	}
+
+	// Parse optional build metadata
+	buildMetadata := ""
+	if len(matches) > 5 && matches[5] != "" {
+		buildMetadata = matches[5]
+	}
+
+	return &Version{
+		original:      original,
+		major:         major,
+		minor:         minor,
+		patch:         patch,
+		preRelease:    preRelease,
+		buildMetadata: buildMetadata,
+	}, nil
+}
+
+func parsePartialVersion(original string, matches []string) (*Version, error) {
+	// Parse major version
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid major version: %s", matches[1])
+	}
+
+	// Parse minor version
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid minor version: %s", matches[2])
+	}
+
+	// Partial versions default to patch 0
+	return &Version{
+		original: original,
+		major:    major,
+		minor:    minor,
+		patch:    0,
+	}, nil
+}
+
+func (v *Version) Compare(other *Version) int {
+	// Compare major.minor.patch first
+	if v.major != other.major {
+		return compareInt(v.major, other.major)
+	}
+	if v.minor != other.minor {
+		return compareInt(v.minor, other.minor)
+	}
+	if v.patch != other.patch {
+		return compareInt(v.patch, other.patch)
+	}
+
+	// Build metadata is ignored in comparisons (SemVer 2.0 rule)
+	// Pre-release versions have lower precedence than normal versions
+	return comparePreRelease(v.preRelease, other.preRelease)
+}
+
+func (v *Version) String() string {
+	return v.original
+}
+
+// comparePreRelease compares pre-release versions following SemVer 2.0 rules
+func comparePreRelease(pr1, pr2 []string) int {
+	// No pre-release (release) is higher than any pre-release
+	if len(pr1) == 0 && len(pr2) == 0 {
+		return 0
+	}
+	if len(pr1) == 0 {
+		return 1 // Release > any pre-release
+	}
+	if len(pr2) == 0 {
+		return -1 // Any pre-release < release
+	}
+
+	// Both have pre-release, compare identifiers one by one
+	maxLen := len(pr1)
+	if len(pr2) > maxLen {
+		maxLen = len(pr2)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		if i >= len(pr1) {
+			return -1 // pr1 has fewer identifiers, so it's less
+		}
+		if i >= len(pr2) {
+			return 1 // pr2 has fewer identifiers, so it's less
+		}
+
+		cmp := comparePreReleaseIdentifier(pr1[i], pr2[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+
+	return 0
+}
+
+// comparePreReleaseIdentifier compares individual pre-release identifiers
+func comparePreReleaseIdentifier(id1, id2 string) int {
+	// Try to parse as integers first
+	num1, err1 := strconv.Atoi(id1)
+	num2, err2 := strconv.Atoi(id2)
+
+	if err1 == nil && err2 == nil {
+		// Both are numbers, compare numerically
+		return compareInt(num1, num2)
+	}
+	if err1 == nil {
+		// id1 is number, id2 is not: number < string
+		return -1
+	}
+	if err2 == nil {
+		// id2 is number, id1 is not: string > number
+		return 1
+	}
+
+	// Both are strings, compare lexicographically
+	if id1 < id2 {
+		return -1
+	}
+	if id1 > id2 {
+		return 1
+	}
+	return 0
+}
+
+func compareInt(a, b int) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/ecosystem/hex/version_test.go
+++ b/pkg/ecosystem/hex/version_test.go
@@ -1,0 +1,451 @@
+package hex
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEcosystem_NewVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *Version
+		wantErr bool
+	}{
+		// Basic semantic versions
+		{
+			name:  "Hex basic version 1.0.0",
+			input: "1.0.0",
+			want: &Version{
+				original: "1.0.0",
+				major:    1,
+				minor:    0,
+				patch:    0,
+			},
+		},
+		{
+			name:  "Hex version 2.3.1",
+			input: "2.3.1",
+			want: &Version{
+				original: "2.3.1",
+				major:    2,
+				minor:    3,
+				patch:    1,
+			},
+		},
+		{
+			name:  "Hex version 0.1.0",
+			input: "0.1.0",
+			want: &Version{
+				original: "0.1.0",
+				major:    0,
+				minor:    1,
+				patch:    0,
+			},
+		},
+		// Pre-release versions
+		{
+			name:  "Hex pre-release 1.0.0-alpha",
+			input: "1.0.0-alpha",
+			want: &Version{
+				original:   "1.0.0-alpha",
+				major:      1,
+				minor:      0,
+				patch:      0,
+				preRelease: []string{"alpha"},
+			},
+		},
+		{
+			name:  "Hex pre-release 1.0.0-alpha.1",
+			input: "1.0.0-alpha.1",
+			want: &Version{
+				original:   "1.0.0-alpha.1",
+				major:      1,
+				minor:      0,
+				patch:      0,
+				preRelease: []string{"alpha", "1"},
+			},
+		},
+		{
+			name:  "Hex pre-release 2.0.0-rc.1",
+			input: "2.0.0-rc.1",
+			want: &Version{
+				original:   "2.0.0-rc.1",
+				major:      2,
+				minor:      0,
+				patch:      0,
+				preRelease: []string{"rc", "1"},
+			},
+		},
+		{
+			name:  "Hex pre-release 1.0.0-beta.2.3",
+			input: "1.0.0-beta.2.3",
+			want: &Version{
+				original:   "1.0.0-beta.2.3",
+				major:      1,
+				minor:      0,
+				patch:      0,
+				preRelease: []string{"beta", "2", "3"},
+			},
+		},
+		// Build metadata versions
+		{
+			name:  "Hex with build metadata 1.0.0+build.1",
+			input: "1.0.0+build.1",
+			want: &Version{
+				original:      "1.0.0+build.1",
+				major:         1,
+				minor:         0,
+				patch:         0,
+				buildMetadata: "build.1",
+			},
+		},
+		{
+			name:  "Hex with build metadata 1.0.0+20130417",
+			input: "1.0.0+20130417",
+			want: &Version{
+				original:      "1.0.0+20130417",
+				major:         1,
+				minor:         0,
+				patch:         0,
+				buildMetadata: "20130417",
+			},
+		},
+		{
+			name:  "Hex pre-release with build metadata 1.0.0-alpha.1+build.1",
+			input: "1.0.0-alpha.1+build.1",
+			want: &Version{
+				original:      "1.0.0-alpha.1+build.1",
+				major:         1,
+				minor:         0,
+				patch:         0,
+				preRelease:    []string{"alpha", "1"},
+				buildMetadata: "build.1",
+			},
+		},
+		// Real Hex package examples
+		{
+			name:  "Phoenix version 1.7.10",
+			input: "1.7.10",
+			want: &Version{
+				original: "1.7.10",
+				major:    1,
+				minor:    7,
+				patch:    10,
+			},
+		},
+		{
+			name:  "Ecto version 3.10.3",
+			input: "3.10.3",
+			want: &Version{
+				original: "3.10.3",
+				major:    3,
+				minor:    10,
+				patch:    3,
+			},
+		},
+		{
+			name:  "Poison pre-release 3.0.0-rc.1",
+			input: "3.0.0-rc.1",
+			want: &Version{
+				original:   "3.0.0-rc.1",
+				major:      3,
+				minor:      0,
+				patch:      0,
+				preRelease: []string{"rc", "1"},
+			},
+		},
+		// Edge cases
+		{
+			name:  "Version with long pre-release 1.0.0-x.7.z.92",
+			input: "1.0.0-x.7.z.92",
+			want: &Version{
+				original:   "1.0.0-x.7.z.92",
+				major:      1,
+				minor:      0,
+				patch:      0,
+				preRelease: []string{"x", "7", "z", "92"},
+			},
+		},
+		{
+			name:  "Version with complex build metadata 1.0.0+exp.sha.5114f85",
+			input: "1.0.0+exp.sha.5114f85",
+			want: &Version{
+				original:      "1.0.0+exp.sha.5114f85",
+				major:         1,
+				minor:         0,
+				patch:         0,
+				buildMetadata: "exp.sha.5114f85",
+			},
+		},
+		// Error cases
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - no patch",
+			input:   "1.2.a",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - no minor",
+			input:   "1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - letters in version numbers",
+			input:   "1.a.3",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - invalid characters",
+			input:   "1.2.3.4",
+			wantErr: true,
+		},
+		{
+			name:    "invalid pre-release - empty identifier",
+			input:   "1.0.0-alpha..1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid format - no major version",
+			input:   ".1.2",
+			wantErr: true,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ecosystem.NewVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Ecosystem.NewVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Ecosystem.NewVersion() got = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersion_Compare(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   string
+		v2   string
+		want int
+	}{
+		// Basic semantic comparisons
+		{
+			name: "same version",
+			v1:   "1.0.0",
+			v2:   "1.0.0",
+			want: 0,
+		},
+		{
+			name: "major version difference",
+			v1:   "1.0.0",
+			v2:   "2.0.0",
+			want: -1,
+		},
+		{
+			name: "minor version difference",
+			v1:   "1.2.0",
+			v2:   "1.3.0",
+			want: -1,
+		},
+		{
+			name: "patch version difference",
+			v1:   "1.0.1",
+			v2:   "1.0.2",
+			want: -1,
+		},
+		// Pre-release comparisons
+		{
+			name: "release vs pre-release",
+			v1:   "1.0.0",
+			v2:   "1.0.0-alpha",
+			want: 1,
+		},
+		{
+			name: "pre-release vs release",
+			v1:   "1.0.0-alpha",
+			v2:   "1.0.0",
+			want: -1,
+		},
+		{
+			name: "alpha vs beta",
+			v1:   "1.0.0-alpha",
+			v2:   "1.0.0-beta",
+			want: -1,
+		},
+		{
+			name: "alpha vs rc",
+			v1:   "1.0.0-alpha",
+			v2:   "1.0.0-rc",
+			want: -1,
+		},
+		{
+			name: "beta vs rc",
+			v1:   "1.0.0-beta",
+			v2:   "1.0.0-rc",
+			want: -1,
+		},
+		{
+			name: "numbered pre-releases",
+			v1:   "1.0.0-alpha.1",
+			v2:   "1.0.0-alpha.2",
+			want: -1,
+		},
+		{
+			name: "alpha vs alpha.1",
+			v1:   "1.0.0-alpha",
+			v2:   "1.0.0-alpha.1",
+			want: -1,
+		},
+		{
+			name: "numeric vs string pre-release",
+			v1:   "1.0.0-1",
+			v2:   "1.0.0-alpha",
+			want: -1,
+		},
+		{
+			name: "complex pre-release comparison",
+			v1:   "1.0.0-alpha.1",
+			v2:   "1.0.0-alpha.beta",
+			want: -1,
+		},
+		// Build metadata (should be ignored)
+		{
+			name: "same version with different build metadata",
+			v1:   "1.0.0+build.1",
+			v2:   "1.0.0+build.2",
+			want: 0,
+		},
+		{
+			name: "version vs version with build metadata",
+			v1:   "1.0.0",
+			v2:   "1.0.0+build.1",
+			want: 0,
+		},
+		{
+			name: "pre-release with build metadata",
+			v1:   "1.0.0-alpha+build.1",
+			v2:   "1.0.0-alpha+build.2",
+			want: 0,
+		},
+		// Real-world Hex comparisons
+		{
+			name: "Phoenix versions",
+			v1:   "1.7.9",
+			v2:   "1.7.10",
+			want: -1,
+		},
+		{
+			name: "Ecto versions",
+			v1:   "3.10.2",
+			v2:   "3.10.3",
+			want: -1,
+		},
+		{
+			name: "Major upgrade",
+			v1:   "2.1.0",
+			v2:   "3.0.0",
+			want: -1,
+		},
+		{
+			name: "RC to release",
+			v1:   "3.0.0-rc.1",
+			v2:   "3.0.0",
+			want: -1,
+		},
+		// Edge cases
+		{
+			name: "zero versions",
+			v1:   "0.1.0",
+			v2:   "0.2.0",
+			want: -1,
+		},
+		{
+			name: "complex pre-release with numbers",
+			v1:   "1.0.0-x.7.z.92",
+			v2:   "1.0.0-x.8.z.92",
+			want: -1,
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v1, err := ecosystem.NewVersion(tt.v1)
+			if err != nil {
+				t.Fatalf("Failed to parse v1 %s: %v", tt.v1, err)
+			}
+			v2, err := ecosystem.NewVersion(tt.v2)
+			if err != nil {
+				t.Fatalf("Failed to parse v2 %s: %v", tt.v2, err)
+			}
+
+			got := v1.Compare(v2)
+			if got != tt.want {
+				t.Errorf("Version.Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersion_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "basic version",
+			input: "1.0.0",
+		},
+		{
+			name:  "version with pre-release",
+			input: "2.0.0-alpha.1",
+		},
+		{
+			name:  "version with build metadata",
+			input: "1.0.0+build.1",
+		},
+		{
+			name:  "version with both",
+			input: "1.0.0-rc.1+build.123",
+		},
+		{
+			name:  "real hex package version",
+			input: "3.10.3",
+		},
+	}
+
+	ecosystem := &Ecosystem{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := ecosystem.NewVersion(tt.input)
+			if err != nil {
+				t.Fatalf("Failed to parse version %s: %v", tt.input, err)
+			}
+
+			if got := v.String(); got != tt.input {
+				t.Errorf("Version.String() = %v, want %v", got, tt.input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Hex ecosystem support addressing issues #79 and #80
- Provides comprehensive version parsing, comparison, and range operations for Hex packages
- Supports both Elixir and Erlang packages uniformly as they use the same versioning scheme

## Features
### Version Support
- **Standard releases**: `1.0.0`, `2.1.3`, `3.10.3`
- **Pre-release versions**: `1.0.0-alpha.1`, `2.0.0-rc.1`, `1.0.0-beta.2.3`
- **Build metadata**: `1.0.0+build.1`, `1.0.0+20130417` (ignored in comparisons per SemVer 2.0)
- **Partial versions**: `1.14` (for pessimistic operator)

### Range Operations
- **Standard operators**: `>=`, `<=`, `>`, `<`, `=`
- **Pessimistic operator**: `~>1.7.0` (≥ 1.7.0 and < 1.8.0), `~>1.14` (≥ 1.14.0 and < 2.0.0)
- **Complex ranges**: `>=1.0.0 <2.0.0`

### CLI Integration
```bash
univers hex compare "1.7.9" "1.7.10"                  # → -1
univers hex sort "1.0.0-alpha.1" "1.0.0" "1.1.0"      # → sorted order
univers hex contains "~>1.7.0" "1.7.10"               # → true
```

## Technical Details
- **SemVer 2.0 compliant**: Follows semantic versioning specification
- **Simplified regex patterns**: Readable and maintainable version parsing
- **Pre-release precedence**: Correctly implements SemVer pre-release ordering rules
- **Build metadata ignored**: Per SemVer specification, build metadata doesn't affect version precedence

## Test Coverage
- **80+ comprehensive test cases** covering all version patterns
- **Table-driven tests** following project conventions
- **Pre-release comparison** edge cases
- **Pessimistic operator** behavior validation
- **Real-world examples** from Phoenix, Ecto, and Elixir packages

## Integration
- Added to CLI ecosystem registry with full command support
- Interface compliance checks in ecosystem.go
- README documentation with complete usage examples
- All quality checks passing (fmt, vet, golangci-lint)

## Design Decision: Universal "Hex" Naming
Following your guidance, implemented as a single "hex" ecosystem rather than separate "elixir"/"erlang" ecosystems, since Hex package manager handles both languages with the same versioning scheme. This makes it clear to users that it's generalizable to anything that Hex can handle.

🤖 Generated with [Claude Code](https://claude.ai/code)